### PR TITLE
Increase timeout

### DIFF
--- a/lib/docusign/connection.ex
+++ b/lib/docusign/connection.ex
@@ -40,7 +40,7 @@ defmodule DocuSign.Connection do
           {Tesla.Middleware.Headers,
            [{"authorization", "#{token.token_type} #{token.access_token}"}]},
           Tesla.Middleware.EncodeJson,
-          {Tesla.Middleware.Timeout, timeout: 5_000}
+          {Tesla.Middleware.Timeout, timeout: 15_000}
         ],
         Tesla.Adapter.Mint
       )


### PR DESCRIPTION
This library has saved us a ton of time. Thank you!

The 5 second timeout is a bit too tight, because we're relying on:
* File I/O
* Network calls

Ideally, this would be configurable, but I think a 15 second timeout is a more reasonable default.