### PR TITLE
Fix: remove nil values from map sent to DocuSign

### DIFF
--- a/test/docusign/request_builder_test.exs
+++ b/test/docusign/request_builder_test.exs
@@ -1,0 +1,22 @@
+defmodule DocuSign.RequestBuilderTest do
+  use ExUnit.Case
+
+  alias DocuSign.RequestBuilder
+
+  describe "adding optional params to request" do
+    test "struct with nil values returns a map with nil values excluded" do
+      request = %{}
+      optional_params = %{
+        EnvelopeRecipientTabs: :body
+      }
+
+      tab =  %DocuSign.Model.Text{tabId: ":id:", value: ":value:", status: nil}
+      tabs = %DocuSign.Model.EnvelopeRecipientTabs{textTabs: [tab], approveTabs: nil}
+      opts = [EnvelopeRecipientTabs: tabs]
+
+      result = RequestBuilder.add_optional_params(request, optional_params, opts)
+
+      assert result == %{body: %{textTabs: [%{tabId: ":id:", value: ":value:"}]}}
+    end
+  end
+end


### PR DESCRIPTION
DocuSign does not handle null values in json objects. See https://github.com/neilberkman/docusign_elixir/issues/23 for details. **It requires Elixir 1.10** (I don't know if that is a problem. If it is, I can have look at adding a defguard for `is_struct` or we bump the elixir version in mix.exs to 1.10).