### PR TITLE
Test timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ end
 
 The docs can be found at [https://hexdocs.pm/docusign](https://hexdocs.pm/docusign).
 
+## Timeout configuration
+
+By default, the HTTP requests will timeout after 30_000 ms. You can configure the timeout:
+
+```elixir
+config :docusign, timeout: 60_000
+```
+
 ## Regenerating stubs
 
 Grab the latest [swagger codegen jar](https://github.com/swagger-api/swagger-codegen#prerequisites) and:

--- a/lib/docusign/connection.ex
+++ b/lib/docusign/connection.ex
@@ -53,7 +53,8 @@ defmodule DocuSign.Connection do
   """
   @spec request(t(), Keyword.t()) :: %OAuth2.Response{}
   def request(conn, opts \\ []) do
-    opts = opts |> Keyword.merge(adapter: [timeout: @timeout])
+    timeout = Application.get_env(:docusign, :timeout, @timeout)
+    opts = opts |> Keyword.merge(opts: [adapter: [timeout: timeout]])
 
     {_, res} =
       conn

--- a/mix.exs
+++ b/mix.exs
@@ -19,9 +19,13 @@ defmodule DocuSign.MixProject do
       maintainers: @maintainers,
       description: "Unofficial DocuSign Elixir Library used to interact with the eSign REST API.",
       homepage_url: @url,
-      deps: deps()
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.
   def application do

--- a/test/docusign/connection_test.exs
+++ b/test/docusign/connection_test.exs
@@ -1,0 +1,53 @@
+defmodule DocuSign.ConnectionTest do
+  use ExUnit.Case, async: false
+
+  alias DocuSign.Connection
+
+  import DocuSign.EnvHelper
+
+  describe "timing out after configured delay" do
+    setup do
+      bypass = Bypass.open()
+
+      {:ok, bypass: bypass}
+    end
+
+    test "request without timeout returns payload", %{bypass: bypass} do
+      Bypass.expect_once(bypass, fn conn ->
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      result = do_request(bypass)
+
+      refute result == :timeout
+    end
+
+    test "request with timeout less than 2s returns :timeout", %{bypass: bypass} do
+      # By default, Mint times out after 2s
+      put_env(:docusign, :timeout, 500)
+
+      Bypass.expect_once(bypass, fn conn ->
+        Process.sleep(1_000)
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      result = do_request(bypass)
+
+      assert result == :timeout
+
+      # Force bypass expectations to pass to prevent exit :shutdown error
+      Bypass.pass(bypass)
+    end
+  end
+
+  defp do_request(bypass) do
+    conn = %Connection{
+      client: %{token: %OAuth2.AccessToken{}},
+      app_account: %DocuSign.User.AppAccount{base_uri: "http://localhost:#{bypass.port}"}
+    }
+
+    opts = [method: :GET, url: "/endpoint"]
+
+    Connection.request(conn, opts)
+  end
+end

--- a/test/support/env_helper.ex
+++ b/test/support/env_helper.ex
@@ -1,0 +1,16 @@
+defmodule DocuSign.EnvHelper do
+  @moduledoc false
+
+  def put_env(app, key, value) do
+    previous_value = Application.get_env(app, key)
+    Application.put_env(app, key, value)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      if is_nil(previous_value) do
+        Application.delete_env(app, key)
+      else
+        Application.put_env(app, key, previous_value)
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Added some tests to make sure Mint is properly configured for the timeout. The benefit is that now, we can configure the timeout.