### PR TITLE
Let Elixir figure out the runtime applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule DocuSign.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      applications: [:logger, :poison, :joken, :oauth2, :tesla, :plug_cowboy],
+      # applications: [:logger, :poison, :joken, :oauth2, :tesla, :plug_cowboy],
+      extra_applications: [:logger],
       mod: {DocuSign.Application, []}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,6 @@ defmodule DocuSign.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      # applications: [:logger, :poison, :joken, :oauth2, :tesla, :plug_cowboy],
       extra_applications: [:logger],
       mod: {DocuSign.Application, []}
     ]


### PR DESCRIPTION
Fixes issue where Mint was not included in mix releases. The error would be something like this when using DocuSign functions: `module Mint.HTTP not found`.

[More details](https://hexdocs.pm/mix/Mix.Tasks.Compile.App.html) on the use of `extra_applications`.