### PR TITLE
Add webhook plug to changelog and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Add support for configuring underlying Tesla adapter.
+- Add webhook plug to simplify DocuSign Connect integration.
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Changelog
 
-## v1.1.2 (unreleased)
+## v1.1.3 (unreleased)
 
 ### Enhancements
 
 - Add support for configuring underlying Tesla adapter.
 - Add webhook plug to simplify DocuSign Connect integration.
 
+## v1.1.2
+
+### Breaking changes
+
+- Increase minimum version of dependencies
+
 ## v1.1.1
 
 ### Breaking Changes
 
 - Change minimum Elixir version to 1.12
+- Increase minimum version of dependencies

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ to any [Tesla adapter][tesla_adapters]:
 config :docusign, adapter: {Tesla.Adapter.Hackney, [recv_timeout: 30_000]}
 ```
 
+## DocuSign Connect
+
+To receive webhooks from DocuSign Connect, you can use `DocuSign.WebhookPlug` with
+your custom webhook handler. See the documentation of `DocuSign.WebhookPlug` for more
+details.
+
 ## Migrating from 0.3.x to 0.4.0
 
 Version 0.4.0 brings the ability to call DocuSign API with different user IDs. This is useful if your


### PR DESCRIPTION
A few documentation changes for webhook plug, assuming the webhook plug will be included in 1.1.2