### PR TITLE
Extend private key options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## v1.1.3
+## v1.2.0 (unreleased)
+
+### Enhancements
+
+- Add support for configuring the private key using either `:private_key_file`
+or `:private_key_contents`.
+    - `:private_key_file` accepts a file path to the private key, exactly like
+      `:private_key`.
+    - `:private_key_contents` is the contents of the private key, typically
+      retrieved from a secrets store.
+
+### Deprecations
+
+- Configuring the private key with `:private_key` was deprecated in favour of
+either `:private_key_file` (same semantics) or `:private_key_contents`.
+
+## v1.1.3 (unreleased)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ or `:private_key_contents`.
 - Configuring the private key with `:private_key` was deprecated in favour of
 either `:private_key_file` (same semantics) or `:private_key_contents`.
 
-## v1.1.3 (unreleased)
+## v1.1.3
 
 ### Enhancements
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You will need to set the following configuration variables in your config file:
 config :docusign,
   hostname: "account-d.docusign.com",
   client_id: "?????-?????-???????",
-  private_key: "docusign_key.pem"
+  private_key_file: "docusign_key.pem"
 ```
 
 Notes:
@@ -67,7 +67,7 @@ And the corresponding config file:
 ```
 config :docusign,
   client_id: System.fetch_env!("DOCUSIGN_CLIENT_ID"),
-  private_key: System.fetch_env!("DOCUSIGN_PRIVATE_KEY")
+  private_key_file: System.fetch_env!("DOCUSIGN_PRIVATE_KEY")
 ```
 
 Then, just be sure to run `source .env` in your shell before compiling your project.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Notes:
 
 - the hostname should be set to `account.docusign.com` for the production environment
 - the path for the private key file can be relative or absolute
+- the private key can also be configured with `private_key_contents`, which is the contents
+of the private key file. This is useful when you do not store the private key on disk,
+but in a secrets store such as Hashicorp Vault or AWS Secrets Manager.
 
 Optional configuration with default values:
 


### PR DESCRIPTION
As discussed in #40

In the next major version, the implementation and tests can be simplified by removing `private_key` altogether.