### PR TITLE
Add unit tests for ModelCleaner to verify nil removal

### DIFF
--- a/test/docusign/model_cleaner_integration_test.exs
+++ b/test/docusign/model_cleaner_integration_test.exs
@@ -1,0 +1,83 @@
+defmodule DocuSign.ModelCleanerIntegrationTest do
+  use ExUnit.Case
+
+  describe "integration with API calls" do
+    test "ModelCleaner is applied to request bodies" do
+      # Create test data with nested nil values
+      envelope_definition = %DocuSign.Model.EnvelopeDefinition{
+        emailSubject: "Test Subject",
+        # This should be removed
+        emailBlurb: nil,
+        status: "created",
+        documents: [
+          %DocuSign.Model.Document{
+            documentBase64: "base64content",
+            name: "Test Document",
+            fileExtension: "pdf",
+            documentId: "1",
+            # This should be removed
+            transformPdfFields: nil
+          }
+        ],
+        recipients: %DocuSign.Model.Recipients{
+          signers: [
+            %DocuSign.Model.Signer{
+              email: "test@example.com",
+              name: "Test Signer",
+              recipientId: "1",
+              routingOrder: "1",
+              tabs: %DocuSign.Model.Tabs{
+                signHereTabs: [
+                  %DocuSign.Model.SignHere{
+                    anchorString: "Sign Here",
+                    anchorXOffset: "0",
+                    # This should be removed
+                    anchorYOffset: nil,
+                    documentId: "1",
+                    recipientId: "1"
+                  }
+                ],
+                # This should be removed
+                dateSignedTabs: nil
+              }
+            }
+          ],
+          # This should be removed
+          carbonCopies: nil
+        }
+      }
+
+      # Instead of testing the entire API call chain which involves Tesla client setup,
+      # let's directly test the ModelCleaner integration in RequestBuilder
+      request = %{}
+
+      result =
+        DocuSign.RequestBuilder.add_optional_params(request, %{body: :body},
+          body: envelope_definition
+        )
+
+      # Extract the cleaned body from the result
+      cleaned_body = result.body
+
+      # Verify it's a map (not a struct)
+      assert is_map(cleaned_body)
+      refute is_struct(cleaned_body)
+
+      # Verify nil values were removed at various levels
+      refute Map.has_key?(cleaned_body, :emailBlurb)
+
+      # Check document
+      document = List.first(cleaned_body.documents)
+      refute Map.has_key?(document, :transformPdfFields)
+
+      # Check nested tabs
+      signer = List.first(cleaned_body.recipients.signers)
+      sign_here = List.first(signer.tabs.signHereTabs)
+      refute Map.has_key?(sign_here, :anchorYOffset)
+
+      # Check removed nil lists/maps
+      refute Map.has_key?(signer.tabs, :dateSignedTabs)
+      refute Map.has_key?(cleaned_body.recipients, :carbonCopies)
+    end
+  end
+end

--- a/test/docusign/model_cleaner_test.exs
+++ b/test/docusign/model_cleaner_test.exs
@@ -1,0 +1,73 @@
+defmodule DocuSign.ModelCleanerTest do
+  use ExUnit.Case, async: true
+
+  alias DocuSign.ModelCleaner
+
+  # Define the test struct at module level, not inside a test
+  defmodule TestStruct do
+    defstruct a: nil, b: 2, c: nil
+  end
+
+  describe "clean/1" do
+    test "returns nil when given nil" do
+      assert ModelCleaner.clean(nil) == nil
+    end
+
+    test "passes through primitive values unchanged" do
+      assert ModelCleaner.clean("string") == "string"
+      assert ModelCleaner.clean(123) == 123
+      assert ModelCleaner.clean(true) == true
+      assert ModelCleaner.clean(false) == false
+      assert ModelCleaner.clean(:atom) == :atom
+    end
+
+    test "removes nil values from maps" do
+      map = %{a: 1, b: nil, c: 3}
+      expected = %{a: 1, c: 3}
+      assert ModelCleaner.clean(map) == expected
+    end
+
+    test "recursively cleans nested maps" do
+      map = %{
+        a: 1,
+        b: nil,
+        c: %{
+          d: 4,
+          e: nil,
+          f: %{g: 7, h: nil}
+        }
+      }
+
+      expected = %{
+        a: 1,
+        c: %{
+          d: 4,
+          f: %{g: 7}
+        }
+      }
+
+      assert ModelCleaner.clean(map) == expected
+    end
+
+    test "recursively cleans lists of maps" do
+      list = [
+        %{a: 1, b: nil},
+        %{c: 3, d: %{e: 5, f: nil}}
+      ]
+
+      expected = [
+        %{a: 1},
+        %{c: 3, d: %{e: 5}}
+      ]
+
+      assert ModelCleaner.clean(list) == expected
+    end
+
+    test "handles structs" do
+      struct = %TestStruct{a: nil, b: 2, c: nil}
+      expected = %{b: 2}
+
+      assert ModelCleaner.clean(struct) == expected
+    end
+  end
+end


### PR DESCRIPTION
Tests verify ModelCleaner removes nil values from structs and maps,
with direct unit tests and integration test with RequestBuilder.
