### PR TITLE
Prepare v2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v2.1.0
 
 ### Enhancements
 - Add support for Elixir 1.18.4 and OTP 28
@@ -33,6 +33,9 @@
 - Remove explicit Mint dependency as it's included transitively via Finch
 - Update LiveBook example to use Kino 0.16.0
 - Update LiveBook to use local path for testing unreleased changes
+- Add Quokka formatter plugin for enhanced code formatting
+- Apply consistent code formatting across entire codebase
+- Add .git-blame-ignore-revs to ignore formatting commits in git blame
 
 ## v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `docusign` to your list of dependencies i
 ```elixir
 def deps do
   [
-    {:docusign, "~> 2.0.0"}
+    {:docusign, "~> 2.1.0"}
   ]
 end
 ```

--- a/examples/embedded_signing.livemd
+++ b/examples/embedded_signing.livemd
@@ -13,7 +13,7 @@ IO.puts("Installing dependencies...")
 Application.put_env(:tesla, :disable_deprecated_builder_warning, true)
 
 Mix.install([
-  {:docusign, path: Path.join(__DIR__, "..")},
+  {:docusign, "~> 2.1.0"},
   {:kino, "~> 0.16.0"}
 ])
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule DocuSign.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "2.0.0"
+  @version "2.1.0"
   @url "https://github.com/neilberkman/docusign_elixir"
   @maintainers [
     "Neil Berkman"


### PR DESCRIPTION
- Update version to 2.1.0 in mix.exs and README.md
- Update CHANGELOG.md with v2.1.0 section including formatting changes
- Fix LiveBook to use published package instead of local path
