### PR TITLE
Add changelog link to Hex package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -92,7 +92,10 @@ defmodule DocuSign.MixProject do
     [
       maintainers: @maintainers,
       licenses: ["MIT"],
-      links: %{github: @url},
+      links: %{
+        "Changelog" => "#{@url}/blob/main/CHANGELOG.md",
+        "GitHub" => @url
+      },
       files:
         ~w(lib) ++
           ~w(LICENSE mix.exs README.md CHANGELOG.md MIGRATING.md examples/embedded_signing.livemd)


### PR DESCRIPTION
This allows users to easily access the changelog directly from the
package page on hex.pm. The link points to the CHANGELOG.md file
in the GitHub repository.
