### PR TITLE
Add model files to Dialyzer ignore list

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,3 +1,8 @@
 [
-  ~r/lib\/docusign\/api\/.*/
+  # Ignore Dialyzer warnings for auto-generated API files
+  ~r/lib\/docusign\/api\/.*/,
+  # Ignore Dialyzer warnings for auto-generated model files
+  # These files contain repetitive struct definitions that may trigger
+  # warnings that are not actionable for generated code
+  ~r/lib\/docusign\/model\/.*/
 ]


### PR DESCRIPTION
Extended .dialyzer_ignore.exs to include auto-generated model files that may produce non-actionable warnings due to repetitive struct definitions and pattern matching patterns.
