### PR TITLE
Implement OAuth2 Authorization Code Flow for DocuSign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,32 @@
 
 ## v2.2.0
 
+### New Features
+- **OAuth2 Authorization Code Flow Support**: Complete implementation of OAuth2 Authorization Code Flow using the battle-tested `oauth2` library
+  - Add `DocuSign.OAuth.AuthorizationCodeStrategy` module implementing OAuth2.Strategy behavior
+  - Add `DocuSign.Connection.from_oauth_client/2` for creating connections from OAuth2.Client
+  - Support automatic token refresh and user info retrieval
+  - Comprehensive test coverage for OAuth2 flow
+- **Interactive LiveBook Guide**: New OAuth2 Authorization Code Flow LiveBook with:
+  - Complete end-to-end OAuth flow demonstration
+  - Built-in Bandit web server for OAuth callbacks
+  - Automatic authorization code capture and token exchange
+  - Real API testing with DocuSign accounts
+  - Production implementation examples and best practices
+
 ### Enhancements
 - Add model files to Dialyzer ignore list to prevent analysis of auto-generated code
 - Add IDEAS.md document cataloging potential improvements from Ruby client
 - Add changelog link to Hex package metadata for better discoverability
+- Remove unnecessary `plug_cowboy` dependency (only used transitively by test dependencies)
+- Update documentation with comprehensive OAuth2 examples
+- Add OAuth2 support to README with complete usage patterns
 
 ### Documentation
 - Create IDEAS.md to track feature ideas and improvements from other DocuSign clients
+
+### Breaking Changes
+- None (fully backward compatible)
 
 ## v2.1.0
 

--- a/examples/oauth_authorization_code_flow.livemd
+++ b/examples/oauth_authorization_code_flow.livemd
@@ -1,0 +1,686 @@
+# Untitled notebook
+
+## DocuSign OAuth2 Authorization Code Flow with Elixir
+
+### Introduction
+
+[![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https://github.com/neilberkman/docusign_elixir/blob/main/examples/oauth_authorization_code_flow.livemd)
+
+This LiveBook demonstrates how to implement the OAuth2 Authorization Code Flow with the DocuSign Elixir SDK using the battle-tested `oauth2` library. This flow is ideal for web applications where users need to grant permission for your application to access their DocuSign account.
+
+The Authorization Code Flow is more secure than JWT impersonation for user-facing applications because:
+
+* Users grant permission explicitly through DocuSign's consent screen
+* No need for admin pre-approval (like JWT impersonation requires)
+* Tokens can be refreshed without user interaction
+* Standard OAuth2 compliance
+* Uses proven OAuth2 library patterns
+
+```elixir
+IO.puts("Installing dependencies...")
+
+# Suppress Tesla deprecation warnings
+Application.put_env(:tesla, :disable_deprecated_builder_warning, true)
+
+Mix.install([
+  {:docusign, path: "/Users/neil/xuku/docusign_elixir"},
+  {:kino, "~> 0.16.0"},
+  {:bandit, "~> 1.7"}
+])
+
+IO.puts("✅ Dependencies installed successfully!")
+```
+
+### OAuth Callback Server
+
+Let's start a simple web server to handle the OAuth callback:
+
+```elixir
+# Create a shared state store for OAuth data
+defmodule OAuthState do
+  use Agent
+
+  def start_link(_) do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  def put(key, value) do
+    Agent.update(__MODULE__, &Map.put(&1, key, value))
+  end
+
+  def get(key) do
+    Agent.get(__MODULE__, &Map.get(&1, key))
+  end
+end
+
+# Start the state store
+{:ok, _} = OAuthState.start_link([])
+
+defmodule OAuthCallbackServer do
+  use Plug.Router
+
+  plug(:match)
+  plug(:dispatch)
+
+  get "/auth/docusign/callback" do
+    # Parse query parameters manually from query_string
+    query_params = if conn.query_string && conn.query_string != "" do
+      URI.decode_query(conn.query_string)
+    else
+      %{}
+    end
+    
+    code = query_params["code"]
+    state = query_params["state"]
+    
+    # Store the code in our shared state
+    OAuthState.put(:code, code)
+    OAuthState.put(:state, state)
+    OAuthState.put(:received_at, DateTime.utc_now())
+    
+    send_resp(conn, 200, """
+    <html>
+      <head><title>DocuSign OAuth Callback</title></head>
+      <body style="font-family: system-ui; text-align: center; padding: 50px;">
+        <h1>✅ Authorization Successful!</h1>
+        <p>You can now close this window and return to LiveBook.</p>
+        <p><strong>Authorization Code:</strong> #{String.slice(code || "none", 0, 20)}...</p>
+        <p><em>The code has been automatically captured for use in LiveBook.</em></p>
+        <script>
+          setTimeout(() => window.close(), 3000);
+        </script>
+      </body>
+    </html>
+    """)
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not found")
+  end
+end
+
+# Start the server
+{:ok, _} = Bandit.start_link(plug: OAuthCallbackServer, port: 4000)
+
+IO.puts("🚀 OAuth callback server started on http://localhost:4000")
+```
+
+### OAuth2 Authorization Code Flow Overview
+
+The OAuth2 Authorization Code Flow consists of these steps:
+
+1. **Generate Authorization URL** - Redirect user to DocuSign for consent
+2. **User Grants Permission** - User signs in and authorizes your app
+3. **Receive Authorization Code** - DocuSign redirects back with a code
+4. **Exchange Code for Tokens** - Trade the code for access/refresh tokens
+5. **Use Tokens for API Calls** - Make authenticated requests to DocuSign
+6. **Refresh Tokens** - Get new access tokens when they expire
+
+### Configuration
+
+First, let's set up our DocuSign OAuth2 configuration:
+
+```elixir
+alias Kino.Input
+
+# Set up input forms for OAuth configuration
+client_id_input = Input.text("Integration Key",
+  label: "Found in the DocuSign admin under Apps & Keys")
+client_secret_input = Input.password("Client Secret",
+  label: "Found in the DocuSign admin under Apps & Keys")
+redirect_uri_input = Input.text("Redirect URI",
+  label: "Must match what's configured in DocuSign admin",
+  default: "http://localhost:4000/auth/docusign/callback")
+is_sandbox_input = Input.checkbox("Use Sandbox", default: true)
+
+# Display input forms individually for proper rendering
+Kino.render(client_id_input)
+Kino.render(client_secret_input)
+Kino.render(redirect_uri_input)
+Kino.render(is_sandbox_input)
+```
+
+Now let's configure the DocuSign OAuth client:
+
+```elixir
+# Get values from inputs
+client_id = Kino.Input.read(client_id_input)
+client_secret = Kino.Input.read(client_secret_input)
+redirect_uri = Kino.Input.read(redirect_uri_input)
+is_sandbox = Kino.Input.read(is_sandbox_input)
+
+# Configure DocuSign application
+hostname = if is_sandbox, do: "account-d.docusign.com", else: "account.docusign.com"
+
+# Use runtime configuration for OAuth
+Application.put_env(:docusign, :hostname, hostname)
+Application.put_env(:docusign, :client_id, client_id)
+Application.put_env(:docusign, :client_secret, client_secret)
+
+# Debug: Check configuration
+IO.puts("OAuth Configuration set:")
+IO.puts("Hostname: #{hostname}")
+IO.puts("Integration Key: #{client_id}")
+IO.puts("Client Secret: #{String.slice(client_secret, 0, 10)}...")
+IO.puts("Redirect URI: #{redirect_uri}")
+IO.puts("Is sandbox: #{is_sandbox}")
+```
+
+### Step 1: Generate Authorization URL
+
+The first step is to create an OAuth2 client and generate an authorization URL where users can grant permission to your application:
+
+```elixir
+# Create OAuth2 client
+oauth_client = DocuSign.OAuth.AuthorizationCodeStrategy.client(
+  redirect_uri: redirect_uri,
+  scope: "signature"
+)
+
+# Generate the authorization URL with CSRF protection
+state = "demo-state-#{:crypto.strong_rand_bytes(8) |> Base.encode16()}"
+authorization_url = OAuth2.Client.authorize_url!(
+  oauth_client,
+  state: state
+)
+
+# Display the authorization URL with a clickable link
+Kino.HTML.new("""
+<div style="margin: 20px 0; padding: 20px; border: 2px solid #007bff; border-radius: 8px; background-color: #f8f9fa;">
+  <h3>Step 1: User Authorization</h3>
+  <p>Click this link to authorize the application in DocuSign:</p>
+  <a href="#{authorization_url}" target="_blank" 
+     style="display: inline-block; background: #007bff; color: white; padding: 12px 24px; 
+            text-decoration: none; border-radius: 4px; font-weight: bold; margin: 10px 0;">
+    🔐 Authorize DocuSign Access
+  </a>
+  <br><br>
+  <details>
+    <summary>🔗 Full Authorization URL (click to expand)</summary>
+    <div style="background: #f1f3f4; padding: 10px; margin-top: 10px; border-radius: 4px; word-break: break-all; font-family: monospace; font-size: 12px;">
+      #{authorization_url}
+    </div>
+  </details>
+  <br>
+  <div style="background: #fff3cd; border: 1px solid #ffeaa7; padding: 15px; border-radius: 4px;">
+    <strong>📝 What happens next:</strong>
+    <ol>
+      <li>Click the authorization link above</li>
+      <li>Sign in to your DocuSign account</li>
+      <li>Review the permissions and click "ALLOW ACCESS"</li>
+      <li>You'll be redirected to your redirect URI with a <code>code</code> parameter</li>
+      <li>Copy the <code>code</code> value and paste it in the next section</li>
+    </ol>
+  </div>
+</div>
+""")
+```
+
+### Step 2: Authorization Code Input
+
+After clicking the authorization link and granting permission, DocuSign will redirect you back to the callback server. The authorization code will be automatically captured:
+
+```elixir
+# Check if we have a code from the callback
+callback_code = OAuthState.get(:code)
+callback_state = OAuthState.get(:state)
+received_at = OAuthState.get(:received_at)
+
+if callback_code do
+  Kino.Markdown.new("""
+  ## ✅ Authorization Code Received!
+  
+  **Code**: `#{String.slice(callback_code, 0, 30)}...`
+  **State**: `#{callback_state}`
+  **Received**: `#{received_at}`
+  
+  The authorization code has been automatically captured from the OAuth callback.
+  """)
+else
+  Kino.Markdown.new("""
+  ## ⏳ Waiting for Authorization...
+  
+  Please click the authorization link above and complete the OAuth flow.
+  The authorization code will appear here automatically once you authorize.
+  """)
+end
+```
+
+### Step 3: Exchange Authorization Code for Tokens
+
+Now let's exchange the authorization code for access and refresh tokens:
+
+```elixir
+# Get the authorization code from the shared state
+auth_code = OAuthState.get(:code)
+
+# Create a frame to display the token exchange results
+token_frame = Kino.Frame.new() |> Kino.render()
+
+if auth_code do
+  Kino.Frame.render(token_frame, Kino.Markdown.new("🔄 Exchanging authorization code for tokens..."))
+
+  # Exchange the authorization code for tokens using OAuth2 library
+  try do
+    oauth_client_with_tokens = OAuth2.Client.get_token!(
+      oauth_client,
+      code: auth_code
+    )
+
+    # Store OAuth2 client for later use (in a real app, you'd store these securely)
+    Process.put(:oauth_client, oauth_client_with_tokens)
+
+    # Extract token information for display
+    token = oauth_client_with_tokens.token
+    expires_in = if token.expires_at do
+      token.expires_at - System.system_time(:second)
+    else
+      "Unknown"
+    end
+
+    Kino.Frame.render(token_frame, Kino.Markdown.new("""
+    ## ✅ Token Exchange Successful!
+
+    Your authorization code has been successfully exchanged for OAuth tokens:
+
+    - **Access Token**: `#{String.slice(token.access_token, 0, 30)}...`
+    - **Refresh Token**: `#{if token.refresh_token, do: String.slice(token.refresh_token, 0, 30) <> "...", else: "Not provided"}`
+    - **Token Type**: `#{token.token_type}`
+    - **Expires In**: `#{expires_in}` seconds
+
+    🎉 You can now use this OAuth2 client to make authenticated API calls to DocuSign!
+    """))
+
+  rescue
+    error ->
+      Kino.Frame.render(token_frame, Kino.Markdown.new("""
+      ## ❌ Token Exchange Failed
+
+      **Error**: `#{inspect(error)}`
+
+      **Common causes:**
+      - Authorization code has expired (they're only valid for a few minutes)
+      - Authorization code has already been used
+      - Redirect URI doesn't match what was used in the authorization step
+      - Invalid client credentials
+
+      **Solution**: Go back to Step 1 and generate a new authorization URL.
+      """))
+  end
+else
+  Kino.Frame.render(token_frame, Kino.Markdown.new("""
+  ⏳ **Waiting for authorization code...**
+
+  Please complete the authorization flow above and paste the authorization code here.
+  """))
+end
+```
+
+### Step 4: Get User Information
+
+Let's use our OAuth tokens to get information about the authenticated user and their DocuSign accounts:
+
+```elixir
+# Create frame for user info
+user_info_frame = Kino.Frame.new() |> Kino.render()
+
+# Check if we have OAuth2 client from the previous step
+oauth_client = Process.get(:oauth_client)
+
+if oauth_client do
+  Kino.Frame.render(user_info_frame, Kino.Markdown.new("🔄 Fetching user information..."))
+
+  # Get user info using the OAuth2 strategy
+  try do
+    user_info = DocuSign.OAuth.AuthorizationCodeStrategy.get_user_info!(oauth_client)
+
+      # Display user information
+      accounts_info = if user_info["accounts"] do
+        user_info["accounts"]
+        |> Enum.with_index(1)
+        |> Enum.map(fn {account, index} ->
+          is_default = Map.get(account, "is_default", "false")
+          default_marker = if is_default == "true", do: " (Default)", else: ""
+
+          """
+          **Account #{index}#{default_marker}:**
+          - Account ID: `#{account["account_id"]}`
+          - Account Name: `#{account["account_name"]}`
+          - Base URI: `#{account["base_uri"]}`
+          """
+        end)
+        |> Enum.join("\n")
+      else
+        "No account information available"
+      end
+
+      Kino.Frame.render(user_info_frame, Kino.Markdown.new("""
+      ## 👤 User Information Retrieved
+
+      **User Details:**
+      - **Name**: #{user_info["name"]}
+      - **Email**: #{user_info["email"]}
+      - **User ID**: `#{user_info["sub"]}`
+      - **Created**: #{user_info["created"]}
+
+      **DocuSign Accounts:**
+      #{accounts_info}
+
+      🎯 **Next**: We'll use the default account to create a DocuSign connection for API calls.
+      """))
+
+    # Store user info for next step
+    Process.put(:user_info, user_info)
+
+  rescue
+    error ->
+      Kino.Frame.render(user_info_frame, Kino.Markdown.new("""
+      ## ❌ Failed to Get User Information
+
+      **Error**: #{inspect(error)}
+
+      This might indicate that your access token is invalid or expired.
+      Please try refreshing the token or re-authorizing.
+      """))
+  end
+else
+  Kino.Frame.render(user_info_frame, Kino.Markdown.new("""
+  ⏳ **Waiting for OAuth tokens...**
+
+  Please complete the token exchange step above first.
+  """))
+end
+```
+
+### Step 5: Create DocuSign Connection
+
+Now let's create a DocuSign connection using our OAuth tokens that we can use for API calls:
+
+```elixir
+# Create frame for connection setup
+connection_frame = Kino.Frame.new() |> Kino.render()
+
+oauth_client = Process.get(:oauth_client)
+user_info = Process.get(:user_info)
+
+if oauth_client && user_info do
+  Kino.Frame.render(connection_frame, Kino.Markdown.new("🔄 Creating DocuSign connection..."))
+
+  # Find the default account or use the first one
+  default_account = user_info["accounts"]
+    |> Enum.find(fn account -> Map.get(account, "is_default") == "true" end)
+
+  default_account = default_account || List.first(user_info["accounts"])
+
+  if default_account do
+    account_id = default_account["account_id"]
+    base_uri = "#{default_account["base_uri"]}/restapi"
+
+    # Create DocuSign connection from OAuth2 client
+    case DocuSign.Connection.from_oauth_client(
+      oauth_client,
+      account_id: account_id,
+      base_uri: base_uri
+    ) do
+      {:ok, conn} ->
+        # Store connection for API usage
+        Process.put(:docusign_connection, conn)
+
+        Kino.Frame.render(connection_frame, Kino.Markdown.new("""
+        ## ✅ DocuSign Connection Created!
+
+        Successfully created a DocuSign connection using OAuth2.Client:
+
+        - **Account ID**: `#{account_id}`
+        - **Account Name**: `#{default_account["account_name"]}`
+        - **API Base URI**: `#{base_uri}`
+        - **Connection Type**: OAuth2 Authorization Code Flow (using oauth2 library)
+
+        🚀 **Ready for API calls!** You can now use this connection with any DocuSign API function.
+        """))
+
+      {:error, reason} ->
+        Kino.Frame.render(connection_frame, Kino.Markdown.new("""
+        ## ❌ Failed to Create Connection
+
+        **Error**: #{inspect(reason)}
+
+        This is unexpected - please check your token and account information.
+        """))
+    end
+  else
+    Kino.Frame.render(connection_frame, Kino.Markdown.new("""
+    ## ❌ No DocuSign Accounts Found
+
+    The user information doesn't contain any DocuSign accounts. This might indicate:
+    - The user doesn't have access to any DocuSign accounts
+    - There's an issue with the OAuth scope or permissions
+
+    Please check your DocuSign account access.
+    """))
+  end
+else
+  Kino.Frame.render(connection_frame, Kino.Markdown.new("""
+  ⏳ **Waiting for tokens and user info...**
+
+  Please complete the previous steps first.
+  """))
+end
+```
+
+### Step 6: Test API Call - Get Account Information
+
+Let's test our OAuth connection by making an API call to get account information:
+
+```elixir
+# Create frame for API test
+api_test_frame = Kino.Frame.new() |> Kino.render()
+
+conn = Process.get(:docusign_connection)
+user_info = Process.get(:user_info)
+
+if conn && user_info do
+  default_account = user_info["accounts"]
+    |> Enum.find(fn account -> Map.get(account, "is_default") == "true" end)
+  default_account = default_account || List.first(user_info["accounts"])
+
+  account_id = default_account["account_id"]
+
+  Kino.Frame.render(api_test_frame, Kino.Markdown.new("🔄 Testing API call..."))
+
+  # Make an API call to get account information
+  case DocuSign.Api.Accounts.accounts_get_account(conn, account_id) do
+    {:ok, account_info} ->
+      Kino.Frame.render(api_test_frame, Kino.Markdown.new("""
+      ## ✅ API Call Successful!
+
+      Successfully retrieved account information using OAuth connection:
+
+      **Account Details:**
+      - **Account Name**: #{account_info.accountName}
+      - **Account ID**: `#{account_info.accountIdGuid}`
+      - **Plan Name**: #{account_info.planName}
+      - **External Account ID**: #{account_info.externalAccountId}
+      - **Created Date**: #{account_info.createdDate}
+      - **Suspension Status**: #{account_info.suspensionStatus}
+
+      **Billing Information:**
+      - **Billing Period**: #{account_info.billingPeriodStartDate} to #{account_info.billingPeriodEndDate}
+      - **Payment Method**: #{account_info.paymentMethod}
+      - **Envelope Unit Price**: #{account_info.envelopeUnitPrice}
+
+      🎉 **OAuth Authorization Code Flow Complete!**
+
+      Your application is now successfully authenticated with DocuSign using OAuth2 tokens and can make API calls on behalf of the user.
+      """))
+
+    {:error, %Tesla.Env{status: status, body: body}} ->
+      Kino.Frame.render(api_test_frame, Kino.Markdown.new("""
+      ## ❌ API Call Failed
+
+      **Status**: #{status}
+      **Response**: #{inspect(body)}
+
+      This might indicate:
+      - Access token has expired
+      - Insufficient permissions
+      - Account access issues
+      """))
+
+    {:error, reason} ->
+      Kino.Frame.render(api_test_frame, Kino.Markdown.new("""
+      ## ❌ API Call Error
+
+      **Error**: #{inspect(reason)}
+
+      There was an unexpected error making the API call.
+      """))
+  end
+else
+  Kino.Frame.render(api_test_frame, Kino.Markdown.new("""
+  ⏳ **Waiting for DocuSign connection...**
+
+  Please complete the connection setup step above first.
+  """))
+end
+```
+
+### Step 7: Token Refresh (Optional)
+
+OAuth access tokens expire (typically after 8 hours). Here's how you can refresh them using the refresh token:
+
+```elixir
+# Create frame for token refresh demo
+refresh_frame = Kino.Frame.new() |> Kino.render()
+
+oauth_client = Process.get(:oauth_client)
+
+if oauth_client && oauth_client.token && oauth_client.token.refresh_token do
+  refresh_button = Kino.Control.button("🔄 Refresh Access Token")
+  Kino.render(refresh_button)
+
+  Kino.listen(refresh_button, fn _ ->
+    Kino.Frame.render(refresh_frame, Kino.Markdown.new("🔄 Refreshing access token..."))
+
+    try do
+      refreshed_client = OAuth2.Client.refresh_token!(oauth_client)
+      
+      # Store new OAuth2 client
+      Process.put(:oauth_client, refreshed_client)
+
+      new_token = refreshed_client.token
+      expires_in = if new_token.expires_at do
+        new_token.expires_at - System.system_time(:second)
+      else
+        "Unknown"
+      end
+
+      Kino.Frame.render(refresh_frame, Kino.Markdown.new("""
+      ## ✅ Token Refresh Successful!
+
+      Your access token has been refreshed:
+
+      - **New Access Token**: `#{String.slice(new_token.access_token, 0, 30)}...`
+      - **New Refresh Token**: `#{if new_token.refresh_token, do: String.slice(new_token.refresh_token, 0, 30) <> "...", else: "Same as before"}`
+      - **Expires In**: `#{expires_in}` seconds
+
+      💡 **Note**: Some OAuth providers rotate refresh tokens, meaning you get a new refresh token each time you refresh. Always use the latest tokens.
+      """))
+
+    rescue
+      error ->
+        Kino.Frame.render(refresh_frame, Kino.Markdown.new("""
+        ## ❌ Token Refresh Failed
+
+        **Error**: `#{inspect(error)}`
+
+        **Common causes:**
+        - Refresh token has expired
+        - Refresh token has been revoked
+        - Invalid client credentials
+
+        **Solution**: The user will need to re-authorize through the full OAuth flow.
+        """))
+    end
+  end)
+
+  Kino.Frame.render(refresh_frame, Kino.Markdown.new("""
+  ## 🔄 Token Refresh
+
+  Click the button above to refresh your access token using the refresh token.
+
+  **When to refresh:**
+  - Before the access token expires (typically 8 hours)
+  - When you receive 401 Unauthorized responses
+  - As part of a scheduled token refresh process
+
+  **In production applications:**
+  - Implement automatic token refresh before expiration
+  - Store tokens securely (encrypted in database)
+  - Handle refresh token rotation properly
+  - Implement fallback to re-authorization flow if refresh fails
+  """))
+else
+  Kino.Frame.render(refresh_frame, Kino.Markdown.new("""
+  ## ℹ️ Token Refresh Not Available
+
+  #{if oauth_client && oauth_client.token do
+      if oauth_client.token.refresh_token do
+        "No refresh token available. Some OAuth flows don't provide refresh tokens."
+      else
+        "No refresh token available from the token exchange."
+      end
+    else
+      "Please complete the OAuth flow first to get tokens."
+    end}
+  """))
+end
+```
+
+### Production Implementation Notes
+
+This LiveBook demonstrates the OAuth2 Authorization Code Flow for DocuSign in an interactive way. When implementing this in a production web application, consider these important points:
+
+#### Security Best Practices
+
+1. **HTTPS Only**: Always use HTTPS for redirect URIs in production
+2. **State Parameter**: Always validate the `state` parameter to prevent CSRF attacks
+3. **Secure Token Storage**: Store tokens encrypted in a secure database
+4. **Token Scoping**: Only request the minimum required OAuth scopes
+
+#### Implementation Patterns
+
+For production Phoenix applications, refer to the comprehensive examples in the [DocuSign Elixir v2.2.0 README](https://github.com/neilberkman/docusign_elixir/blob/v2.2.0/README.md#oauth2-authorization-code-flow) which includes complete Phoenix controller implementation, token management patterns, and security best practices.
+
+## Conclusion
+
+🎉 **Congratulations!** You've successfully implemented the OAuth2 Authorization Code Flow with DocuSign:
+
+1. ✅ Generated authorization URL for user consent
+2. ✅ Exchanged authorization code for access/refresh tokens
+3. ✅ Retrieved user information using OAuth tokens
+4. ✅ Created DocuSign connection from OAuth tokens
+5. ✅ Made authenticated API calls to DocuSign
+6. ✅ Demonstrated token refresh functionality
+
+### Key Benefits of OAuth2 Authorization Code Flow:
+
+* **User Control**: Users explicitly grant permission through DocuSign's interface
+* **No Admin Pre-approval**: Unlike JWT impersonation, no admin setup required
+* **Standard Compliance**: Uses industry-standard OAuth2 flow
+* **Token Refresh**: Long-term access through refresh tokens
+* **Secure**: Follows OAuth2 security best practices
+
+### Next Steps:
+
+* Implement this flow in your web application
+* Set up secure token storage and management
+* Handle token refresh and expiration gracefully
+* Add error handling and user feedback
+* Consider implementing webhook notifications for document status updates
+
+For more information, check out the [DocuSign Elixir GitHub repository](https://github.com/neilberkman/docusign_elixir) and the [official DocuSign API documentation](https://developers.docusign.com/).
+
+```
+
+```

--- a/lib/docusign/oauth/authorization_code_strategy.ex
+++ b/lib/docusign/oauth/authorization_code_strategy.ex
@@ -1,0 +1,163 @@
+defmodule DocuSign.OAuth.AuthorizationCodeStrategy do
+  @moduledoc """
+  OAuth2 Authorization Code Flow strategy for DocuSign using the battle-tested oauth2 library.
+
+  This module implements the standard OAuth2 Authorization Code Flow for DocuSign,
+  leveraging the existing OAuth2 library infrastructure used by the JWT impersonation flow.
+
+  ## Usage
+
+      # Create client
+      client = DocuSign.OAuth.AuthorizationCodeStrategy.client(
+        client_id: "your_integration_key",
+        client_secret: "your_secret",
+        redirect_uri: "https://yourapp.com/auth/docusign/callback"
+      )
+
+      # Generate authorization URL
+      auth_url = OAuth2.Client.authorize_url!(client, scope: "signature")
+
+      # Exchange authorization code for tokens
+      client = OAuth2.Client.get_token!(client, code: "auth_code_from_callback")
+
+      # Get DocuSign user info
+      user_info = DocuSign.OAuth.AuthorizationCodeStrategy.get_user_info!(client)
+
+  ## Configuration
+
+      config :docusign,
+        client_id: "your_integration_key",
+        client_secret: "your_secret_key", 
+        hostname: "account-d.docusign.com"  # or "account.docusign.com" for production
+  """
+
+  use OAuth2.Strategy
+
+  alias OAuth2.{Client, Strategy.AuthCode}
+
+  @doc """
+  Create a new OAuth2 client for DocuSign Authorization Code Flow.
+
+  ## Parameters
+
+  - `opts` - Keyword list of options:
+    - `:client_id` - DocuSign integration key (required if not in app config)
+    - `:client_secret` - DocuSign secret (required if not in app config)
+    - `:hostname` - DocuSign hostname (required if not in app config)
+    - `:redirect_uri` - Callback URL for authorization (required)
+    - `:scope` - OAuth scopes (default: "signature")
+
+  ## Examples
+
+      # With explicit configuration
+      client = DocuSign.OAuth.AuthorizationCodeStrategy.client(
+        client_id: "your_integration_key",
+        client_secret: "your_secret",
+        hostname: "account-d.docusign.com",
+        redirect_uri: "https://yourapp.com/auth/callback"
+      )
+
+      # Using application config
+      client = DocuSign.OAuth.AuthorizationCodeStrategy.client(
+        redirect_uri: "https://yourapp.com/auth/callback"
+      )
+
+  ## Returns
+
+  Returns an `OAuth2.Client` struct configured for DocuSign Authorization Code Flow.
+  """
+  @spec client(keyword()) :: OAuth2.Client.t()
+  def client(opts \\ []) do
+    client_id = get_required_option(opts, :client_id, &get_client_id/0)
+    client_secret = get_required_option(opts, :client_secret, &get_client_secret/0)
+    hostname = get_required_option(opts, :hostname, &get_hostname/0)
+    redirect_uri = Keyword.fetch!(opts, :redirect_uri)
+    scope = Keyword.get(opts, :scope, "signature")
+
+    [
+      strategy: __MODULE__,
+      client_id: client_id,
+      client_secret: client_secret,
+      site: "https://#{hostname}",
+      authorize_url: "/oauth/auth",
+      token_url: "/oauth/token",
+      redirect_uri: redirect_uri
+    ]
+    |> Keyword.merge(opts)
+    |> Client.new()
+    |> Client.put_serializer("application/json", Jason)
+    |> Client.put_param(:scope, scope)
+  end
+
+  @doc """
+  Get DocuSign user information using the access token.
+
+  ## Parameters
+
+  - `client` - OAuth2.Client with valid access token
+
+  ## Examples
+
+      user_info = get_user_info!(client)
+      user_email = user_info["email"]
+      accounts = user_info["accounts"]
+
+  ## Returns
+
+  Returns user information map from DocuSign /oauth/userinfo endpoint.
+  """
+  @spec get_user_info!(OAuth2.Client.t()) :: map()
+  def get_user_info!(client) do
+    case Client.get(client, "/oauth/userinfo") do
+      {:ok, %{body: body}} -> body
+      {:error, error} -> raise "Failed to get user info: #{inspect(error)}"
+    end
+  end
+
+  # OAuth2.Strategy callbacks
+
+  @impl OAuth2.Strategy
+  def authorize_url(client, params) do
+    AuthCode.authorize_url(client, params)
+  end
+
+  @impl OAuth2.Strategy
+  def get_token(client, params, headers) do
+    client
+    |> Client.put_param(:grant_type, "authorization_code")
+    |> Client.put_param(:code, params[:code])
+    |> Client.put_param(:redirect_uri, client.redirect_uri)
+    |> Client.put_header("accept", "application/json")
+    |> AuthCode.get_token(params, headers)
+  end
+
+  # Private helper functions
+
+  defp get_required_option(opts, key, fallback_fn) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} -> value
+      :error -> fallback_fn.()
+    end
+  end
+
+  defp get_client_id do
+    case Application.fetch_env(:docusign, :client_id) do
+      {:ok, client_id} -> client_id
+      :error -> raise ArgumentError, "client_id is required (set in opts or app config)"
+    end
+  end
+
+  defp get_client_secret do
+    case Application.fetch_env(:docusign, :client_secret) do
+      {:ok, client_secret} -> client_secret
+      :error -> raise ArgumentError, "client_secret is required (set in opts or app config)"
+    end
+  end
+
+  defp get_hostname do
+    case Application.fetch_env(:docusign, :hostname) do
+      {:ok, hostname} -> hostname
+      :error -> raise ArgumentError, "hostname is required (set in opts or app config)"
+    end
+  end
+end

--- a/lib/docusign/request_builder.ex
+++ b/lib/docusign/request_builder.ex
@@ -186,7 +186,7 @@ defmodule DocuSign.RequestBuilder do
   def evaluate_response({:error, _} = error, _), do: error
 
   defp resolve_mapping(%Tesla.Env{status: status} = env, [{mapping_status, struct} | _], _)
-      when status == mapping_status do
+       when status == mapping_status do
     decode(env, struct)
   end
 

--- a/lib/docusign/webhook_plug.ex
+++ b/lib/docusign/webhook_plug.ex
@@ -153,8 +153,8 @@ defmodule DocuSign.WebhookPlug do
     {:ok, payload, conn} = Conn.read_body(conn)
 
     with :ok <- verify_signatures(payload, secret, signatures(conn)),
-        {:ok, %{} = event} <- parse_payload(payload),
-        :ok <- handle_event!(handler, event) do
+         {:ok, %{} = event} <- parse_payload(payload),
+         :ok <- handle_event!(handler, event) do
       halt(send_resp(conn, 200, "Webhook received."))
     else
       {:handle_error, reason} -> halt(send_resp(conn, 400, reason))

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,6 @@ defmodule DocuSign.MixProject do
       {:jason, "~> 1.4"},
       {:joken, "~> 2.0"},
       {:oauth2, "~> 2.0"},
-      {:plug_cowboy, "~> 2.7.3"},
       {:castore, "~> 1.0"},
       {:finch, "~> 0.19"},
       {:meck, "~> 0.9.2"},
@@ -69,7 +68,13 @@ defmodule DocuSign.MixProject do
 
   defp docs do
     [
-      extras: ["README.md", "CHANGELOG.md", "MIGRATING.md", "examples/embedded_signing.livemd"],
+      extras: [
+        "README.md",
+        "CHANGELOG.md",
+        "MIGRATING.md",
+        "examples/embedded_signing.livemd",
+        "examples/oauth_authorization_code_flow.livemd"
+      ],
       main: "readme",
       source_ref: "v#{@version}",
       source_url: @url,
@@ -98,7 +103,7 @@ defmodule DocuSign.MixProject do
       },
       files:
         ~w(lib) ++
-          ~w(LICENSE mix.exs README.md CHANGELOG.md MIGRATING.md examples/embedded_signing.livemd)
+          ~w(LICENSE mix.exs README.md CHANGELOG.md MIGRATING.md examples/embedded_signing.livemd examples/oauth_authorization_code_flow.livemd)
     ]
   end
 end

--- a/test/docusign/connection_oauth_test.exs
+++ b/test/docusign/connection_oauth_test.exs
@@ -1,0 +1,219 @@
+defmodule DocuSign.ConnectionOAuthTest do
+  use ExUnit.Case, async: true
+
+  alias DocuSign.Connection
+  alias OAuth2.{AccessToken, Client}
+
+  describe "from_oauth_client/2" do
+    test "creates connection from OAuth2.Client with tokens" do
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "oauth_access_token_123",
+          expires_at: System.system_time(:second) + 28_800,
+          refresh_token: "oauth_refresh_token_456",
+          token_type: "Bearer"
+        }
+      }
+
+      {:ok, conn} =
+        Connection.from_oauth_client(
+          oauth_client,
+          account_id: "12345678-1234-1234-1234-123456789012",
+          base_uri: "https://demo.docusign.net/restapi"
+        )
+
+      assert conn.client == oauth_client
+      assert conn.app_account.account_id == "12345678-1234-1234-1234-123456789012"
+      assert conn.app_account.base_uri == "https://demo.docusign.net/restapi"
+    end
+
+    test "returns error when account_id is missing" do
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "oauth_access_token_123",
+          token_type: "Bearer"
+        }
+      }
+
+      {:error, reason} =
+        Connection.from_oauth_client(
+          oauth_client,
+          base_uri: "https://demo.docusign.net/restapi"
+        )
+
+      assert reason == {:missing_required_option, :account_id}
+    end
+
+    test "returns error when base_uri is missing" do
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "oauth_access_token_123",
+          token_type: "Bearer"
+        }
+      }
+
+      {:error, reason} =
+        Connection.from_oauth_client(
+          oauth_client,
+          account_id: "12345678-1234-1234-1234-123456789012"
+        )
+
+      assert reason == {:missing_required_option, :base_uri}
+    end
+  end
+
+  describe "Connection.Request.new/1 with OAuth2.Client" do
+    test "creates Tesla client with OAuth2.Client authorization" do
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "oauth_access_token_123",
+          expires_at: System.system_time(:second) + 28_800,
+          refresh_token: "oauth_refresh_token_456",
+          token_type: "Bearer"
+        }
+      }
+
+      conn = %Connection{
+        app_account: %{
+          base_uri: "https://demo.docusign.net/restapi"
+        },
+        client: oauth_client
+      }
+
+      tesla_client = Connection.Request.new(conn)
+
+      # Check that Tesla client is created (we can't easily inspect middleware)
+      assert %Tesla.Client{} = tesla_client
+    end
+
+    test "creates Tesla client with JWT token authorization (existing behavior)" do
+      conn = %Connection{
+        app_account: %{
+          base_uri: "https://demo.docusign.net/restapi"
+        },
+        client: %{
+          token: %{
+            access_token: "jwt_access_token_123",
+            token_type: "Bearer"
+          }
+        }
+      }
+
+      tesla_client = Connection.Request.new(conn)
+
+      # Check that Tesla client is created (we can't easily inspect middleware)
+      assert %Tesla.Client{} = tesla_client
+    end
+  end
+
+  describe "Connection.request/2 with OAuth2.Client" do
+    setup do
+      bypass = Bypass.open()
+
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "oauth_access_token_123",
+          expires_at: System.system_time(:second) + 28_800,
+          refresh_token: "oauth_refresh_token_456",
+          token_type: "Bearer"
+        }
+      }
+
+      conn = %Connection{
+        app_account: %{
+          base_uri: "http://localhost:#{bypass.port}"
+        },
+        client: oauth_client
+      }
+
+      {:ok, bypass: bypass, conn: conn}
+    end
+
+    test "makes successful request with OAuth2.Client", %{bypass: bypass, conn: conn} do
+      Bypass.expect_once(bypass, "GET", "/test", fn conn ->
+        # Verify the Authorization header
+        auth_header = get_req_header(conn, "authorization") |> List.first()
+        assert auth_header == "Bearer oauth_access_token_123"
+
+        Plug.Conn.resp(conn, 200, Jason.encode!(%{"success" => true}))
+      end)
+
+      {:ok, response} = Connection.request(conn, method: :get, url: "/test")
+
+      assert response.status == 200
+      assert Jason.decode!(response.body) == %{"success" => true}
+    end
+
+    test "handles request errors with OAuth2.Client", %{bypass: bypass, conn: conn} do
+      Bypass.expect_once(bypass, "GET", "/error", fn conn ->
+        Plug.Conn.resp(conn, 401, Jason.encode!(%{"error" => "unauthorized"}))
+      end)
+
+      {:ok, response} = Connection.request(conn, method: :get, url: "/error")
+
+      assert response.status == 401
+      assert Jason.decode!(response.body) == %{"error" => "unauthorized"}
+    end
+
+    defp get_req_header(conn, name) do
+      Plug.Conn.get_req_header(conn, name)
+    end
+  end
+
+  describe "Integration: OAuth2 strategy to Connection usage" do
+    test "complete flow using OAuth2.Client" do
+      # Simulate OAuth2.Client with tokens from authorization flow
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "integration_access_token",
+          expires_at: System.system_time(:second) + 28_800,
+          refresh_token: "integration_refresh_token",
+          token_type: "Bearer"
+        }
+      }
+
+      # Create connection from OAuth2.Client
+      {:ok, conn} =
+        Connection.from_oauth_client(
+          oauth_client,
+          account_id: "12345678-1234-1234-1234-123456789012",
+          base_uri: "https://demo.docusign.net/restapi"
+        )
+
+      # Verify connection structure
+      assert conn.client == oauth_client
+      assert conn.app_account.account_id == "12345678-1234-1234-1234-123456789012"
+      assert conn.app_account.base_uri == "https://demo.docusign.net/restapi"
+
+      # Verify we can create a Tesla client for requests
+      tesla_client = Connection.Request.new(conn)
+      assert %Tesla.Client{} = tesla_client
+    end
+
+    test "connection works with typical DocuSign API patterns" do
+      oauth_client = %Client{
+        token: %AccessToken{
+          access_token: "api_access_token",
+          expires_at: System.system_time(:second) + 28_800,
+          refresh_token: "api_refresh_token",
+          token_type: "Bearer"
+        }
+      }
+
+      {:ok, conn} =
+        Connection.from_oauth_client(
+          oauth_client,
+          account_id: "api-account-id",
+          base_uri: "https://demo.docusign.net/restapi"
+        )
+
+      # This connection structure should work with existing DocuSign API modules
+      # We can't test actual API calls without mocking, but we can verify structure
+      assert is_map(conn.app_account)
+      assert %Client{} = conn.client
+
+      # Verify compatibility with Connection.request/2
+      assert is_function(&Connection.request/2, 2)
+    end
+  end
+end

--- a/test/docusign/oauth/authorization_code_strategy_test.exs
+++ b/test/docusign/oauth/authorization_code_strategy_test.exs
@@ -1,0 +1,234 @@
+defmodule DocuSign.OAuth.AuthorizationCodeStrategyTest do
+  use ExUnit.Case, async: false
+
+  alias DocuSign.OAuth.AuthorizationCodeStrategy
+  alias OAuth2.{AccessToken, Client}
+
+  setup do
+    # Ensure the module is loaded
+    Code.ensure_loaded(AuthorizationCodeStrategy)
+
+    # Save current environment and clean slate for each test
+    original_client_id = Application.get_env(:docusign, :client_id)
+    original_client_secret = Application.get_env(:docusign, :client_secret)
+    original_hostname = Application.get_env(:docusign, :hostname)
+
+    Application.delete_env(:docusign, :client_id)
+    Application.delete_env(:docusign, :client_secret)
+    Application.delete_env(:docusign, :hostname)
+
+    on_exit(fn ->
+      # Restore original values
+      if original_client_id, do: Application.put_env(:docusign, :client_id, original_client_id)
+
+      if original_client_secret,
+        do: Application.put_env(:docusign, :client_secret, original_client_secret)
+
+      if original_hostname, do: Application.put_env(:docusign, :hostname, original_hostname)
+    end)
+
+    :ok
+  end
+
+  describe "client/1" do
+    test "creates OAuth2 client with explicit configuration" do
+      client =
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com",
+          redirect_uri: "https://example.com/callback"
+        )
+
+      assert %Client{} = client
+      assert client.client_id == "test_client_id"
+      assert client.client_secret == "test_client_secret"
+      assert client.site == "https://account-d.docusign.com"
+      assert client.authorize_url == "/oauth/auth"
+      assert client.token_url == "/oauth/token"
+      assert client.redirect_uri == "https://example.com/callback"
+      assert client.params["scope"] == "signature"
+    end
+
+    test "creates OAuth2 client with custom scope" do
+      client =
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com",
+          redirect_uri: "https://example.com/callback",
+          scope: "signature impersonation"
+        )
+
+      assert client.params["scope"] == "signature impersonation"
+    end
+
+    test "uses application config when options not provided" do
+      Application.put_env(:docusign, :client_id, "app_client_id")
+      Application.put_env(:docusign, :client_secret, "app_client_secret")
+      Application.put_env(:docusign, :hostname, "account.docusign.com")
+
+      client =
+        AuthorizationCodeStrategy.client(redirect_uri: "https://example.com/callback")
+
+      assert client.client_id == "app_client_id"
+      assert client.client_secret == "app_client_secret"
+      assert client.site == "https://account.docusign.com"
+    end
+
+    test "raises error when required parameters are missing" do
+      assert_raise ArgumentError, "client_id is required (set in opts or app config)", fn ->
+        AuthorizationCodeStrategy.client(redirect_uri: "https://example.com/callback")
+      end
+    end
+
+    test "raises error when redirect_uri is missing" do
+      assert_raise KeyError, fn ->
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com"
+        )
+      end
+    end
+  end
+
+  describe "authorize_url!/2" do
+    setup do
+      client =
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com",
+          redirect_uri: "https://example.com/callback"
+        )
+
+      {:ok, client: client}
+    end
+
+    test "generates correct authorization URL", %{client: client} do
+      url = OAuth2.Client.authorize_url!(client)
+
+      assert url =~ "https://account-d.docusign.com/oauth/auth"
+      assert url =~ "response_type=code"
+      assert url =~ "client_id=test_client_id"
+      assert url =~ "redirect_uri=https%3A%2F%2Fexample.com%2Fcallback"
+      assert url =~ "scope=signature"
+    end
+
+    test "includes state parameter when provided", %{client: client} do
+      url = OAuth2.Client.authorize_url!(client, state: "random_state_123")
+
+      assert url =~ "state=random_state_123"
+    end
+
+    test "includes custom scope when provided", %{client: client} do
+      url =
+        OAuth2.Client.authorize_url!(client, scope: "signature impersonation")
+
+      assert url =~ "scope=signature+impersonation"
+    end
+  end
+
+  describe "OAuth2 integration" do
+    test "follows OAuth2 strategy pattern" do
+      # Test that our strategy implements the OAuth2.Strategy behavior
+      assert function_exported?(AuthorizationCodeStrategy, :get_token, 3)
+      # authorize_url/2 is an @impl callback, not a public function
+      assert {:authorize_url, 2} in AuthorizationCodeStrategy.__info__(:functions)
+    end
+
+    test "creates client with proper strategy configuration" do
+      client =
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com",
+          redirect_uri: "https://example.com/callback"
+        )
+
+      assert client.strategy == AuthorizationCodeStrategy
+    end
+
+    test "client can be used with OAuth2.Client functions" do
+      client =
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com",
+          redirect_uri: "https://example.com/callback"
+        )
+
+      # Test that we can call OAuth2.Client functions
+      auth_url = Client.authorize_url!(client)
+      assert is_binary(auth_url)
+      assert auth_url =~ "account-d.docusign.com"
+    end
+
+    test "client supports token refresh functionality" do
+      # Create a client with a mock access token
+      client =
+        AuthorizationCodeStrategy.client(
+          client_id: "test_client_id",
+          client_secret: "test_client_secret",
+          hostname: "account-d.docusign.com",
+          redirect_uri: "https://example.com/callback"
+        )
+
+      # Add a mock token with refresh token
+      token = %AccessToken{
+        access_token: "mock_access_token",
+        expires_at: System.system_time(:second) + 3600,
+        refresh_token: "mock_refresh_token",
+        token_type: "Bearer"
+      }
+
+      _client_with_token = %{client | token: token}
+
+      # Test that OAuth2.Client.refresh_token! function exists and can be called
+      # (In real usage, this would make HTTP request)
+      assert function_exported?(OAuth2.Client, :refresh_token!, 1)
+    end
+  end
+
+  describe "helper functions" do
+    test "get_user_info! function exists" do
+      assert function_exported?(AuthorizationCodeStrategy, :get_user_info!, 1)
+    end
+
+    test "OAuth2.Client functions are available" do
+      assert function_exported?(OAuth2.Client, :get_token!, 2)
+      assert function_exported?(OAuth2.Client, :refresh_token!, 1)
+      assert function_exported?(OAuth2.Client, :authorize_url!, 1)
+    end
+  end
+
+  describe "configuration validation" do
+    test "validates client_id from app config" do
+      Application.put_env(:docusign, :client_secret, "secret")
+      Application.put_env(:docusign, :hostname, "hostname")
+
+      assert_raise ArgumentError, "client_id is required (set in opts or app config)", fn ->
+        AuthorizationCodeStrategy.client(redirect_uri: "https://example.com/callback")
+      end
+    end
+
+    test "validates client_secret from app config" do
+      Application.put_env(:docusign, :client_id, "client_id")
+      Application.put_env(:docusign, :hostname, "hostname")
+
+      assert_raise ArgumentError, "client_secret is required (set in opts or app config)", fn ->
+        AuthorizationCodeStrategy.client(redirect_uri: "https://example.com/callback")
+      end
+    end
+
+    test "validates hostname from app config" do
+      Application.put_env(:docusign, :client_id, "client_id")
+      Application.put_env(:docusign, :client_secret, "secret")
+
+      assert_raise ArgumentError, "hostname is required (set in opts or app config)", fn ->
+        AuthorizationCodeStrategy.client(redirect_uri: "https://example.com/callback")
+      end
+    end
+  end
+end

--- a/test/docusign/oauth/impl_test.exs
+++ b/test/docusign/oauth/impl_test.exs
@@ -36,11 +36,11 @@ defmodule DocuSign.OAuth.ImplTest do
     client = OAuth.Impl.get_token!(OAuth.Impl.client(site: "http://localhost:#{bypass.port}"))
 
     assert %OAuth2.AccessToken{
-            access_token: "ISSUED_ACCESS_TOKEN",
-            other_params: %{},
-            refresh_token: "ISSUED_REFRESH_TOKEN",
-            token_type: "Bearer"
-          } = client.token
+             access_token: "ISSUED_ACCESS_TOKEN",
+             other_params: %{},
+             refresh_token: "ISSUED_REFRESH_TOKEN",
+             token_type: "Bearer"
+           } = client.token
   end
 
   test "token_expired?" do
@@ -57,40 +57,40 @@ defmodule DocuSign.OAuth.ImplTest do
   describe "creating new API client" do
     test "create new api client for default user ID" do
       assert %Client{
-              ref: %{
-                user_id: ":user-id:"
-              },
-              request_opts: [],
-              site: "http://localhost",
-              strategy: Impl,
-              token: nil,
-              token_method: :post,
-              token_url: "/oauth/token"
-            } = OAuth.Impl.client(site: "http://localhost")
+               ref: %{
+                 user_id: ":user-id:"
+               },
+               request_opts: [],
+               site: "http://localhost",
+               strategy: Impl,
+               token: nil,
+               token_method: :post,
+               token_url: "/oauth/token"
+             } = OAuth.Impl.client(site: "http://localhost")
     end
 
     test "create new api client for given user ID" do
       assert %Client{
-              ref: %{
-                user_id: ":other-user-id:"
-              },
-              request_opts: [],
-              site: "http://localhost",
-              strategy: Impl,
-              token: nil,
-              token_method: :post,
-              token_url: "/oauth/token"
-            } = OAuth.Impl.client(user_id: ":other-user-id:", site: "http://localhost")
+               ref: %{
+                 user_id: ":other-user-id:"
+               },
+               request_opts: [],
+               site: "http://localhost",
+               strategy: Impl,
+               token: nil,
+               token_method: :post,
+               token_url: "/oauth/token"
+             } = OAuth.Impl.client(user_id: ":other-user-id:", site: "http://localhost")
     end
   end
 
   test "get_token" do
     assert %Client{
-            params: %{
-              "assertion" => _,
-              "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer"
-            }
-          } = OAuth.Impl.get_token(OAuth.Impl.client(site: "http://localhost"), [], [])
+             params: %{
+               "assertion" => _,
+               "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer"
+             }
+           } = OAuth.Impl.get_token(OAuth.Impl.client(site: "http://localhost"), [], [])
   end
 
   test "refresh_token!", %{bypass: bypass} do
@@ -112,12 +112,12 @@ defmodule DocuSign.OAuth.ImplTest do
     assert %AccessToken{access_token: "TEST_TOKEN"} = OAuth.Impl.refresh_token!(client).token
 
     assert %AccessToken{access_token: "ISSUED_ACCESS_TOKEN"} =
-            OAuth.Impl.refresh_token!(client, true).token
+             OAuth.Impl.refresh_token!(client, true).token
 
     expired_client = %{client | token: %AccessToken{expires_at: now - 3600}}
 
     assert %AccessToken{access_token: "ISSUED_ACCESS_TOKEN"} =
-            OAuth.Impl.refresh_token!(expired_client).token
+             OAuth.Impl.refresh_token!(expired_client).token
   end
 
   test "interval_refresh_token" do
@@ -157,21 +157,21 @@ defmodule DocuSign.OAuth.ImplTest do
 
     # == DocuSign.Util.map_keys_to_atoms(user_info)
     assert info == %{
-            "accounts" => [
-              %{
-                "account_id" => "61ac4bd1-c83c-4aa6-8654-d3b44a252f42",
-                "account_name" => "Tandem Equity LLC",
-                "base_uri" => "https://demo.docusign.net",
-                "is_default" => true
-              }
-            ],
-            "created" => "2018-09-07T23:49:34.163",
-            "email" => "neil@test.com",
-            "family_name" => "Test",
-            "given_name" => "Neil",
-            "name" => "Neil Test1",
-            "sub" => "84a39dd2-b972-48b2-929a-cf743466a4d5"
-          }
+             "accounts" => [
+               %{
+                 "account_id" => "61ac4bd1-c83c-4aa6-8654-d3b44a252f42",
+                 "account_name" => "Tandem Equity LLC",
+                 "base_uri" => "https://demo.docusign.net",
+                 "is_default" => true
+               }
+             ],
+             "created" => "2018-09-07T23:49:34.163",
+             "email" => "neil@test.com",
+             "family_name" => "Test",
+             "given_name" => "Neil",
+             "name" => "Neil Test1",
+             "sub" => "84a39dd2-b972-48b2-929a-cf743466a4d5"
+           }
   end
 
   describe "private key configuration" do
@@ -209,10 +209,10 @@ defmodule DocuSign.OAuth.ImplTest do
       Application.delete_env(:docusign, :private_key_contents)
 
       assert_raise RuntimeError,
-                  "No private key found in application environment. Please set :private_key_file or :private_key_contents.",
-                  fn ->
-                    OAuth.Impl.get_token!(OAuth.Impl.client(site: "http://localhost:#{bypass.port}"))
-                  end
+                   "No private key found in application environment. Please set :private_key_file or :private_key_contents.",
+                   fn ->
+                     OAuth.Impl.get_token!(OAuth.Impl.client(site: "http://localhost:#{bypass.port}"))
+                   end
     end
 
     test "raises if multiple private key configuration keys are used", %{bypass: bypass} do
@@ -220,10 +220,10 @@ defmodule DocuSign.OAuth.ImplTest do
       Application.put_env(:docusign, :private_key_contents, File.read!("test/support/test_key"))
 
       assert_raise RuntimeError,
-                  "Multiple DocuSign private keys were provided. Please use only one of :private_key_file or :private_key_contents.",
-                  fn ->
-                    OAuth.Impl.get_token!(OAuth.Impl.client(site: "http://localhost:#{bypass.port}"))
-                  end
+                   "Multiple DocuSign private keys were provided. Please use only one of :private_key_file or :private_key_contents.",
+                   fn ->
+                     OAuth.Impl.get_token!(OAuth.Impl.client(site: "http://localhost:#{bypass.port}"))
+                   end
     end
   end
 

--- a/test/docusign/user_test.exs
+++ b/test/docusign/user_test.exs
@@ -21,21 +21,21 @@ defmodule DocuSign.UserTest do
       result = User.info(client)
 
       assert %DocuSign.User{
-              accounts: [
-                %AppAccount{
-                  account_id: ":account-id:",
-                  account_name: ":account-name:",
-                  base_uri: "https://demo.docusign.net",
-                  is_default: true
-                }
-              ],
-              created: "2018-09-07T23:49:34.163",
-              email: ":email:",
-              family_name: ":family-name:",
-              given_name: ":given-name:",
-              name: ":name:",
-              sub: ":user-id:"
-            } = result
+               accounts: [
+                 %AppAccount{
+                   account_id: ":account-id:",
+                   account_name: ":account-name:",
+                   base_uri: "https://demo.docusign.net",
+                   is_default: true
+                 }
+               ],
+               created: "2018-09-07T23:49:34.163",
+               email: ":email:",
+               family_name: ":family-name:",
+               given_name: ":given-name:",
+               name: ":name:",
+               sub: ":user-id:"
+             } = result
     end
   end
 end

--- a/test/docusign/webhook_plug_test.exs
+++ b/test/docusign/webhook_plug_test.exs
@@ -43,10 +43,10 @@ defmodule DocuSign.WebhookPlugTest do
                           )
 
   @opts_with_tuple_handler WebhookPlug.init(
-                            at: "/webhook/docusign",
-                            handler: __MODULE__.StubTupleHandler,
-                            hmac_secret_key: "sample-hmac-key"
-                          )
+                             at: "/webhook/docusign",
+                             handler: __MODULE__.StubTupleHandler,
+                             hmac_secret_key: "sample-hmac-key"
+                           )
 
   @opts_with_error_atom_handler WebhookPlug.init(
                                   at: "/webhook/docusign",
@@ -55,22 +55,22 @@ defmodule DocuSign.WebhookPlugTest do
                                 )
 
   @opts_with_error_atom_reason_handler WebhookPlug.init(
-                                        at: "/webhook/docusign",
-                                        handler: __MODULE__.ErrorAtomReasonHandler,
-                                        hmac_secret_key: "sample-hmac-key"
-                                      )
+                                         at: "/webhook/docusign",
+                                         handler: __MODULE__.ErrorAtomReasonHandler,
+                                         hmac_secret_key: "sample-hmac-key"
+                                       )
 
   @opts_with_error_string_reason_handler WebhookPlug.init(
-                                          at: "/webhook/docusign",
-                                          handler: __MODULE__.ErrorStringReasonHandler,
-                                          hmac_secret_key: "sample-hmac-key"
-                                        )
+                                           at: "/webhook/docusign",
+                                           handler: __MODULE__.ErrorStringReasonHandler,
+                                           hmac_secret_key: "sample-hmac-key"
+                                         )
 
   @opts_with_bad_handler WebhookPlug.init(
-                          at: "/webhook/docusign",
-                          handler: __MODULE__.BadHandler,
-                          hmac_secret_key: "sample-hmac-key"
-                        )
+                           at: "/webhook/docusign",
+                           handler: __MODULE__.BadHandler,
+                           hmac_secret_key: "sample-hmac-key"
+                         )
 
   defmodule StubHandler do
     @moduledoc """


### PR DESCRIPTION
Added comprehensive OAuth2 Authorization Code Flow support using the battle-tested oauth2 library, providing an alternative to JWT impersonation for user-facing applications.

## New Features

### OAuth2 Authorization Code Strategy (`DocuSign.OAuth.AuthorizationCodeStrategy`)
- Implements OAuth2.Strategy behavior for DocuSign
- Configurable via application config or runtime options
- Clean API: `client/1` for setup, `get_user_info\!/1` for DocuSign-specific functionality
- Uses OAuth2.Client functions directly (authorize_url\!, get_token\!, refresh_token\!)
- No wrapper functions to avoid reinventing the wheel

### Enhanced Connection Module
- Added `from_oauth_client/2` function to create connections from OAuth2.Client
- Updated Connection.Request.new/1 with pattern matching for OAuth2.Client vs JWT clients
- Maintains backward compatibility with existing JWT impersonation flow
- Updated documentation with OAuth2 usage examples

### Comprehensive Test Suite
- OAuth2 strategy tests covering configuration, client creation, and OAuth2 integration
- Connection tests for OAuth2.Client integration and HTTP request handling
- Integration tests demonstrating complete OAuth flow to API usage
- All tests pass with proper OAuth2 patterns

### Interactive LiveBook Documentation
- Complete OAuth2 Authorization Code Flow walkthrough
- Step-by-step implementation with user interaction
- Real-world examples including error handling and token refresh
- Production implementation patterns and security best practices
- Token management and refresh functionality demonstration

## Key Benefits

- **User Control**: Explicit permission through DocuSign's consent screen
- **No Admin Setup**: Unlike JWT impersonation, no admin pre-approval required
- **Standard Compliance**: Industry-standard OAuth2 Authorization Code Flow
- **Token Refresh**: Long-term access through refresh tokens
- **Battle-tested**: Leverages existing oauth2 library infrastructure
- **Clean Architecture**: Maintains Elixir's superior patterns while adding missing functionality

## Usage

```elixir
# Create OAuth2 client
client = DocuSign.OAuth.AuthorizationCodeStrategy.client(
  redirect_uri: "https://yourapp.com/auth/callback"
)

# Generate authorization URL
auth_url = OAuth2.Client.authorize_url\!(client, scope: "signature")

# Exchange code for tokens
client = OAuth2.Client.get_token\!(client, code: "auth_code")

# Get user info and create connection
user_info = DocuSign.OAuth.AuthorizationCodeStrategy.get_user_info\!(client)
account = Enum.find(user_info["accounts"], &(&1["is_default"] == "true"))

{:ok, conn} = DocuSign.Connection.from_oauth_client(
  client,
  account_id: account["account_id"],
  base_uri: account["base_uri"] <> "/restapi"
)

# Use connection with any DocuSign API
{:ok, users} = DocuSign.Api.Users.users_get_users(conn, account["account_id"])
```