### PR TITLE
Fix CI formatting checks: restrict to latest Elixir version only

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -72,4 +72,5 @@ jobs:
           mix test --trace
 
       - name: Check formatting
+        if: matrix.elixir == '1.18.4' && matrix.otp == '28.0'
         run: mix format --check-formatted


### PR DESCRIPTION
## Summary

Fixes CI formatting failures by restricting format checks to only run on the latest Elixir version (1.18.4 with OTP 28.0).

## Problem

Different Elixir versions have slightly different formatting rules, causing CI to fail on older versions (1.16.3) while passing on newer ones (1.18.4). This creates inconsistent CI results where the same code passes formatting on some versions but fails on others.

## Solution

Modified the GitHub Actions workflow to add a conditional check (`if: matrix.elixir == '1.18.4' && matrix.otp == '28.0'`) to the formatting step, ensuring format checks only run on the latest supported Elixir version.

## Benefits

- ✅ Eliminates version-specific formatting inconsistencies in CI
- ✅ Maintains code quality standards using the latest formatter
- ✅ Reduces CI noise from formatting differences across Elixir versions
- ✅ Follows common practice of using latest tooling for code quality checks

## Test plan

- [x] Verify workflow syntax is correct
- [x] Commit includes only the necessary conditional change
- [ ] Observe CI runs to confirm formatting only runs on Elixir 1.18.4/OTP 28.0
- [ ] Verify other Elixir versions still run tests successfully without formatting checks
