### PR TITLE
Fix connection test failing in CI due to missing OAuth config

### DIFF
--- a/test/docusign/connection_test.exs
+++ b/test/docusign/connection_test.exs
@@ -39,6 +39,15 @@ defmodule DocuSign.ConnectionTest do
     end
 
     test "consent required OAuth error returns error :consent_required" do
+      # Set required config for build_consent_url
+      Application.put_env(:docusign, :client_id, "test-client-id")
+      Application.put_env(:docusign, :hostname, "test.docusign.com")
+
+      on_exit(fn ->
+        Application.delete_env(:docusign, :client_id)
+        Application.delete_env(:docusign, :hostname)
+      end)
+
       @oauth_mock
       |> expect(:client, fn opts ->
         %OAuth2.Client{ref: %{user_id: opts[:user_id]}}


### PR DESCRIPTION
## Summary

This PR fixes a test that was failing in CI due to missing configuration.

## Problem

The  test in  was failing with:



This happens because the test triggers an error path that calls , which requires  and  to be configured.

## Solution

Added the necessary configuration setup and teardown to the test to ensure these values are available when needed.

## Testing

- The test now passes locally and in CI
- No other changes needed as this is just a test fix