### PR TITLE
Add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/docusign)](https://hex.pm/packages/docusign)
 [![Hexdocs.pm](https://img.shields.io/badge/docs-hexdocs.pm-purple)](https://hexdocs.pm/docusign)
-[![Github.com](https://github.com/neilberkman/docusign_elixir/actions/workflows/ci.yml/badge.svg)](https://github.com/neilberkman/docusign_elixir/actions)
+[![Github.com](https://github.com/neilberkman/docusign_elixir/actions/workflows/elixir.yml/badge.svg)](https://github.com/neilberkman/docusign_elixir/actions)
 
 # DocuSign API Client
 


### PR DESCRIPTION
Fix GitHub Actions badge URL to use correct workflow filename (elixir.yml)
