### PR TITLE
Fix Dialyzer errors and add Dialyzer to CI (fixes #76)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,8 +1,13 @@
 [
   # Ignore Dialyzer warnings for auto-generated API files
+  # These files use keyword() which Dialyzer sees as :elixir.keyword()
   ~r/lib\/docusign\/api\/.*/,
   # Ignore Dialyzer warnings for auto-generated model files
   # These files contain repetitive struct definitions that may trigger
   # warnings that are not actionable for generated code
-  ~r/lib\/docusign\/model\/.*/
+  ~r/lib\/docusign\/model\/.*/,
+  # Ignore false positive invalid_contract warnings for Connection and FileDownloader
+  # These occur when Dialyzer incorrectly infers the success typing
+  {"lib/docusign/connection.ex", :invalid_contract},
+  {"lib/docusign/file_downloader.ex", :invalid_contract}
 ]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -74,3 +74,7 @@ jobs:
       - name: Check formatting
         if: matrix.elixir == '1.18.4' && matrix.otp == '28.0'
         run: mix format --check-formatted
+
+      - name: Run Dialyzer
+        if: matrix.elixir == '1.18.4' && matrix.otp == '28.0'
+        run: mix dialyzer

--- a/lib/docusign/api/account_brands.ex
+++ b/lib/docusign/api/account_brands.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brand_delete_brand(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brand_delete_brand(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def brand_delete_brand(connection, account_id, brand_id, _opts \\ []) do
     request =
@@ -64,7 +64,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brand_export_get_brand_export_file(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brand_export_get_brand_export_file(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def brand_export_get_brand_export_file(connection, account_id, brand_id, _opts \\ []) do
     request =
@@ -99,7 +99,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, DocuSign.Model.Brand.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brand_get_brand(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brand_get_brand(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, Brand.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -142,7 +142,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec brand_logo_delete_brand_logo(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -181,7 +181,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec brand_logo_get_brand_logo(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -221,7 +221,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec brand_logo_put_brand_logo(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -262,7 +262,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, DocuSign.Model.Brand.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brand_put_brand(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brand_put_brand(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, Brand.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -308,7 +308,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec brand_resources_get_brand_resources(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -352,7 +352,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec brand_resources_get_brand_resources_list(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -394,7 +394,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec brand_resources_put_brand_resources(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -443,7 +443,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, DocuSign.Model.AccountBrands.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brands_delete_brands(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec brands_delete_brands(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountBrands.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -484,7 +484,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, DocuSign.Model.AccountBrands.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brands_get_brands(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec brands_get_brands(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountBrands.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -525,7 +525,7 @@ defmodule DocuSign.Api.AccountBrands do
   - `{:ok, DocuSign.Model.AccountBrands.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brands_post_brands(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec brands_post_brands(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountBrands.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/account_consumer_disclosures.ex
+++ b/lib/docusign/api/account_consumer_disclosures.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.AccountConsumerDisclosures do
   - `{:ok, DocuSign.Model.AccountConsumerDisclosures.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec consumer_disclosure_get_consumer_disclosure(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec consumer_disclosure_get_consumer_disclosure(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, AccountConsumerDisclosures.t()}
           | {:error, Tesla.Env.t()}
@@ -70,7 +70,7 @@ defmodule DocuSign.Api.AccountConsumerDisclosures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec consumer_disclosure_get_consumer_disclosure_lang_code(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -112,7 +112,7 @@ defmodule DocuSign.Api.AccountConsumerDisclosures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec consumer_disclosure_put_consumer_disclosure(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/account_custom_fields.ex
+++ b/lib/docusign/api/account_custom_fields.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.AccountCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_custom_fields_delete_account_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -70,7 +70,7 @@ defmodule DocuSign.Api.AccountCustomFields do
   - `{:ok, DocuSign.Model.AccountCustomFields.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec account_custom_fields_get_account_custom_fields(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec account_custom_fields_get_account_custom_fields(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountCustomFields.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -107,7 +107,7 @@ defmodule DocuSign.Api.AccountCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_custom_fields_post_account_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -155,7 +155,7 @@ defmodule DocuSign.Api.AccountCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_custom_fields_put_account_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/account_password_rules.ex
+++ b/lib/docusign/api/account_password_rules.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.AccountPasswordRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_password_rules_get_account_password_rules(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -68,7 +68,7 @@ defmodule DocuSign.Api.AccountPasswordRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_password_rules_put_account_password_rules(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -109,7 +109,7 @@ defmodule DocuSign.Api.AccountPasswordRules do
   - `{:ok, DocuSign.Model.UserPasswordRules.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec password_rules_get_password_rules(Tesla.Env.client(), keyword()) ::
+  @spec password_rules_get_password_rules(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, UserPasswordRules.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/account_permission_profiles.ex
+++ b/lib/docusign/api/account_permission_profiles.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.AccountPermissionProfiles do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec permission_profiles_delete_permission_profiles(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -74,7 +74,7 @@ defmodule DocuSign.Api.AccountPermissionProfiles do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec permission_profiles_get_permission_profile(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -118,7 +118,7 @@ defmodule DocuSign.Api.AccountPermissionProfiles do
   - `{:ok, DocuSign.Model.PermissionProfileInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec permission_profiles_get_permission_profiles(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec permission_profiles_get_permission_profiles(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PermissionProfileInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -159,7 +159,7 @@ defmodule DocuSign.Api.AccountPermissionProfiles do
   - `{:ok, DocuSign.Model.PermissionProfile.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec permission_profiles_post_permission_profiles(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec permission_profiles_post_permission_profiles(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PermissionProfile.t()}
           | {:error, Tesla.Env.t()}
@@ -204,7 +204,7 @@ defmodule DocuSign.Api.AccountPermissionProfiles do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec permission_profiles_put_permission_profiles(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/account_seal_providers.ex
+++ b/lib/docusign/api/account_seal_providers.ex
@@ -26,7 +26,7 @@ defmodule DocuSign.Api.AccountSealProviders do
   - `{:ok, DocuSign.Model.AccountSealProviders.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec account_signature_providers_get_seal_providers(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec account_signature_providers_get_seal_providers(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, AccountSealProviders.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/account_signature_providers.ex
+++ b/lib/docusign/api/account_signature_providers.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.AccountSignatureProviders do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signature_providers_get_signature_providers(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::

--- a/lib/docusign/api/account_signatures.ex
+++ b/lib/docusign/api/account_signatures.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signatures_delete_account_signature(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -68,7 +68,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signatures_delete_account_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -109,7 +109,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signatures_get_account_signature(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -151,7 +151,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signatures_get_account_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -195,7 +195,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:ok, DocuSign.Model.AccountSignaturesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec account_signatures_get_account_signatures(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec account_signatures_get_account_signatures(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountSignaturesInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -238,7 +238,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:ok, DocuSign.Model.AccountSignaturesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec account_signatures_post_account_signatures(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec account_signatures_post_account_signatures(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountSignaturesInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -280,7 +280,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:ok, DocuSign.Model.AccountSignaturesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec account_signatures_put_account_signature(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec account_signatures_put_account_signature(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountSignaturesInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -324,7 +324,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signatures_put_account_signature_by_id(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -373,7 +373,7 @@ defmodule DocuSign.Api.AccountSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_signatures_put_account_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/account_tab_settings.ex
+++ b/lib/docusign/api/account_tab_settings.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.Api.AccountTabSettings do
   - `{:ok, DocuSign.Model.TabAccountSettings.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tab_settings_get_tab_settings(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec tab_settings_get_tab_settings(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, TabAccountSettings.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -62,7 +62,7 @@ defmodule DocuSign.Api.AccountTabSettings do
   - `{:ok, DocuSign.Model.TabAccountSettings.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tab_settings_put_settings(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec tab_settings_put_settings(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, TabAccountSettings.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/account_watermarks.ex
+++ b/lib/docusign/api/account_watermarks.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.Api.AccountWatermarks do
   - `{:ok, DocuSign.Model.Watermark.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec watermark_get_watermark(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec watermark_get_watermark(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, Watermark.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -62,7 +62,7 @@ defmodule DocuSign.Api.AccountWatermarks do
   - `{:ok, DocuSign.Model.Watermark.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec watermark_preview_put_watermark_preview(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec watermark_preview_put_watermark_preview(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, Watermark.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -103,7 +103,7 @@ defmodule DocuSign.Api.AccountWatermarks do
   - `{:ok, DocuSign.Model.Watermark.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec watermark_put_watermark(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec watermark_put_watermark(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, Watermark.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/accounts.ex
+++ b/lib/docusign/api/accounts.ex
@@ -39,7 +39,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec accounts_delete_account(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec accounts_delete_account(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def accounts_delete_account(connection, account_id, opts \\ []) do
     optional_params = %{
@@ -77,7 +77,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.AccountInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec accounts_get_account(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec accounts_get_account(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, AccountInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -115,7 +115,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.ProvisioningInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec accounts_get_provisioning(Tesla.Env.client(), keyword()) ::
+  @spec accounts_get_provisioning(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ProvisioningInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -149,7 +149,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.NewAccountSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec accounts_post_accounts(Tesla.Env.client(), keyword()) ::
+  @spec accounts_post_accounts(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NewAccountSummary.t()}
           | {:error, Tesla.Env.t()}
@@ -190,7 +190,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.BillingChargeResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_charges_get_account_billing_charges(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_charges_get_account_billing_charges(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BillingChargeResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -232,7 +232,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec captive_recipients_delete_captive_recipients_part(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -276,7 +276,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_purge_configuration_get_envelope_purge_configuration(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -315,7 +315,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_purge_configuration_put_envelope_purge_configuration(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -358,7 +358,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.NotificationDefaults.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notification_defaults_get_notification_defaults(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec notification_defaults_get_notification_defaults(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NotificationDefaults.t()}
           | {:error, Tesla.Env.t()}
@@ -393,7 +393,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.NotificationDefaults.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notification_defaults_put_notification_defaults(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec notification_defaults_put_notification_defaults(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NotificationDefaults.t()}
           | {:error, Tesla.Env.t()}
@@ -434,7 +434,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.RecipientNamesResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipient_names_get_recipient_names(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec recipient_names_get_recipient_names(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, RecipientNamesResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -473,7 +473,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.AccountSettingsInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec settings_get_settings(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec settings_get_settings(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountSettingsInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -508,7 +508,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec settings_put_settings(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec settings_put_settings(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def settings_put_settings(connection, account_id, opts \\ []) do
     optional_params = %{
@@ -554,7 +554,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.AccountSharedAccess.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec shared_access_get_shared_access(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec shared_access_get_shared_access(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, AccountSharedAccess.t()}
           | {:error, Tesla.Env.t()}
@@ -604,7 +604,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.AccountSharedAccess.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec shared_access_put_shared_access(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec shared_access_put_shared_access(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, AccountSharedAccess.t()}
           | {:error, Tesla.Env.t()}
@@ -647,7 +647,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:ok, DocuSign.Model.SupportedLanguages.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec supported_languages_get_supported_languages(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec supported_languages_get_supported_languages(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, SupportedLanguages.t()}
           | {:error, Tesla.Env.t()}
@@ -682,7 +682,7 @@ defmodule DocuSign.Api.Accounts do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec unsupported_file_types_get_unsupported_file_types(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::

--- a/lib/docusign/api/authorizations.ex
+++ b/lib/docusign/api/authorizations.ex
@@ -39,7 +39,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_agent_authorizations_get_agent_user_authorizations(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -91,7 +91,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorization_create_user_authorization(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -138,7 +138,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorization_delete_user_authorization(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -177,7 +177,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorization_get_user_authorization(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -220,7 +220,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorization_update_user_authorization(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -268,7 +268,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorizations_delete_user_authorizations(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -320,7 +320,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorizations_get_principal_user_authorizations(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -372,7 +372,7 @@ defmodule DocuSign.Api.Authorizations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_authorizations_post_user_authorizations(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/bcc_email_archive.ex
+++ b/lib/docusign/api/bcc_email_archive.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.BCCEmailArchive do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec b_cc_email_archive_delete_bcc_email_archive(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -70,7 +70,7 @@ defmodule DocuSign.Api.BCCEmailArchive do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec b_cc_email_archive_get_bcc_email_archive_history_list(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -116,7 +116,7 @@ defmodule DocuSign.Api.BCCEmailArchive do
   - `{:ok, DocuSign.Model.BccEmailArchiveList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec b_cc_email_archive_get_bcc_email_archive_list(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec b_cc_email_archive_get_bcc_email_archive_list(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BccEmailArchiveList.t()}
           | {:error, Tesla.Env.t()}
@@ -157,7 +157,7 @@ defmodule DocuSign.Api.BCCEmailArchive do
   - `{:ok, DocuSign.Model.BccEmailArchive.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec b_cc_email_archive_post_bcc_email_archive(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec b_cc_email_archive_post_bcc_email_archive(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BccEmailArchive.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/billing_plans.ex
+++ b/lib/docusign/api/billing_plans.ex
@@ -38,7 +38,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.AccountBillingPlanResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plan_get_billing_plan(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_plan_get_billing_plan(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, AccountBillingPlanResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -81,7 +81,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.CreditCardInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plan_get_credit_card_info(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_plan_get_credit_card_info(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, CreditCardInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -114,7 +114,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.DowngradRequestBillingInfoResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plan_get_downgrade_request_billing_info(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_plan_get_downgrade_request_billing_info(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, DowngradRequestBillingInfoResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -150,7 +150,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.BillingPlanUpdateResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plan_put_billing_plan(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_plan_put_billing_plan(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, BillingPlanUpdateResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -191,7 +191,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.DowngradePlanUpdateResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plan_put_downgrade_account_billing_plan(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_plan_put_downgrade_account_billing_plan(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, DowngradePlanUpdateResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -231,7 +231,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.BillingPlanResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plans_get_billing_plan(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_plans_get_billing_plan(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, BillingPlanResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -264,7 +264,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, DocuSign.Model.BillingPlansResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_plans_get_billing_plans(Tesla.Env.client(), keyword()) ::
+  @spec billing_plans_get_billing_plans(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BillingPlansResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -299,7 +299,7 @@ defmodule DocuSign.Api.BillingPlans do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec purchased_envelopes_put_purchased_envelopes(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec purchased_envelopes_put_purchased_envelopes(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def purchased_envelopes_put_purchased_envelopes(connection, account_id, opts \\ []) do
     optional_params = %{

--- a/lib/docusign/api/bulk_send.ex
+++ b/lib/docusign/api/bulk_send.ex
@@ -35,7 +35,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_batch_get_bulk_send_batch_status(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -81,7 +81,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:ok, DocuSign.Model.BulkSendBatchSummaries.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec bulk_send_v2_batch_get_bulk_send_batches(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec bulk_send_v2_batch_get_bulk_send_batches(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BulkSendBatchSummaries.t()}
           | {:error, Tesla.Env.t()}
@@ -131,7 +131,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_batch_put_bulk_send_batch_action(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -179,7 +179,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_batch_put_bulk_send_batch_status(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -225,7 +225,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_crud_delete_bulk_send_list(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -265,7 +265,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_crud_get_bulk_send_list(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -303,7 +303,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:ok, DocuSign.Model.BulkSendingListSummaries.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec bulk_send_v2_crud_get_bulk_send_lists(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec bulk_send_v2_crud_get_bulk_send_lists(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BulkSendingListSummaries.t()}
           | {:error, Tesla.Env.t()}
@@ -338,7 +338,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:ok, DocuSign.Model.BulkSendingList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec bulk_send_v2_crud_post_bulk_send_list(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec bulk_send_v2_crud_post_bulk_send_list(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, BulkSendingList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -381,7 +381,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_crud_put_bulk_send_list(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -434,7 +434,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_envelopes_get_bulk_send_batch_envelopes(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -486,7 +486,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_send_post_bulk_send_request(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -533,7 +533,7 @@ defmodule DocuSign.Api.BulkSend do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec bulk_send_v2_test_post_bulk_send_test_request(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/chunked_uploads.ex
+++ b/lib/docusign/api/chunked_uploads.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.ChunkedUploads do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec chunked_uploads_delete_chunked_upload(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -69,7 +69,7 @@ defmodule DocuSign.Api.ChunkedUploads do
   - `{:ok, DocuSign.Model.ChunkedUploadResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec chunked_uploads_get_chunked_upload(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec chunked_uploads_get_chunked_upload(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ChunkedUploadResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -109,7 +109,7 @@ defmodule DocuSign.Api.ChunkedUploads do
   - `{:ok, DocuSign.Model.ChunkedUploadResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec chunked_uploads_post_chunked_uploads(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec chunked_uploads_post_chunked_uploads(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ChunkedUploadResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -153,7 +153,7 @@ defmodule DocuSign.Api.ChunkedUploads do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec chunked_uploads_put_chunked_upload_part(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -206,7 +206,7 @@ defmodule DocuSign.Api.ChunkedUploads do
   - `{:ok, DocuSign.Model.ChunkedUploadResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec chunked_uploads_put_chunked_uploads(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec chunked_uploads_put_chunked_uploads(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ChunkedUploadResponse.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/cloud_storage.ex
+++ b/lib/docusign/api/cloud_storage.ex
@@ -39,7 +39,7 @@ defmodule DocuSign.Api.CloudStorage do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec cloud_storage_folder_get_cloud_storage_folder(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -100,7 +100,7 @@ defmodule DocuSign.Api.CloudStorage do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec cloud_storage_folder_get_cloud_storage_folder_all(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/cloud_storage_providers.ex
+++ b/lib/docusign/api/cloud_storage_providers.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.CloudStorageProviders do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec cloud_storage_delete_cloud_storage(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -72,7 +72,7 @@ defmodule DocuSign.Api.CloudStorageProviders do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec cloud_storage_delete_cloud_storage_providers(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -119,7 +119,7 @@ defmodule DocuSign.Api.CloudStorageProviders do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec cloud_storage_get_cloud_storage(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -166,7 +166,7 @@ defmodule DocuSign.Api.CloudStorageProviders do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec cloud_storage_get_cloud_storage_providers(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -211,7 +211,7 @@ defmodule DocuSign.Api.CloudStorageProviders do
   - `{:ok, DocuSign.Model.CloudStorageProviders.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec cloud_storage_post_cloud_storage(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec cloud_storage_post_cloud_storage(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, CloudStorageProviders.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/comments.ex
+++ b/lib/docusign/api/comments.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.Comments do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec comments_get_comments_transcript(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec comments_get_comments_transcript(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()} | {:ok, String.t()} | {:error, Tesla.Env.t()}
   def comments_get_comments_transcript(connection, account_id, envelope_id, opts \\ []) do
     optional_params = %{

--- a/lib/docusign/api/connect_configurations.ex
+++ b/lib/docusign/api/connect_configurations.ex
@@ -32,7 +32,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_delete_connect_config(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec connect_delete_connect_config(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def connect_delete_connect_config(connection, account_id, connect_id, _opts \\ []) do
     request =
@@ -71,7 +71,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.IntegratedConnectUserInfoList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_get_connect_all_users(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec connect_get_connect_all_users(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, IntegratedConnectUserInfoList.t()}
           | {:error, Tesla.Env.t()}
@@ -116,7 +116,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.ConnectConfigResults.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_get_connect_config(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec connect_get_connect_config(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectConfigResults.t()}
           | {:error, Tesla.Env.t()}
@@ -150,7 +150,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.ConnectConfigResults.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_get_connect_configs(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_get_connect_configs(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectConfigResults.t()}
           | {:error, Tesla.Env.t()}
@@ -191,7 +191,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.IntegratedUserInfoList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_get_connect_users(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec connect_get_connect_users(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, IntegratedUserInfoList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -236,7 +236,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec connect_o_auth_config_delete_connect_o_auth_config(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) :: {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
@@ -270,7 +270,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.ConnectOAuthConfig.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_o_auth_config_get_connect_o_auth_config(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_o_auth_config_get_connect_o_auth_config(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectOAuthConfig.t()}
           | {:error, Tesla.Env.t()}
@@ -306,7 +306,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec connect_o_auth_config_post_connect_o_auth_config(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -349,7 +349,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.ConnectOAuthConfig.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_o_auth_config_put_connect_o_auth_config(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_o_auth_config_put_connect_o_auth_config(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectOAuthConfig.t()}
           | {:error, Tesla.Env.t()}
@@ -390,7 +390,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.ConnectCustomConfiguration.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_post_connect_configuration(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_post_connect_configuration(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectCustomConfiguration.t()}
           | {:error, Tesla.Env.t()}
@@ -431,7 +431,7 @@ defmodule DocuSign.Api.ConnectConfigurations do
   - `{:ok, DocuSign.Model.ConnectCustomConfiguration.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_put_connect_configuration(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_put_connect_configuration(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectCustomConfiguration.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/connect_events.ex
+++ b/lib/docusign/api/connect_events.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec connect_failures_delete_connect_failure_log(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -68,7 +68,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:ok, DocuSign.Model.ConnectLogs.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_failures_get_connect_logs(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_failures_get_connect_logs(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectLogs.t()}
           | {:error, Tesla.Env.t()}
@@ -109,7 +109,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_log_delete_connect_log(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec connect_log_delete_connect_log(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def connect_log_delete_connect_log(connection, account_id, log_id, _opts \\ []) do
     request =
@@ -141,7 +141,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_log_delete_connect_logs(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_log_delete_connect_logs(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def connect_log_delete_connect_logs(connection, account_id, _opts \\ []) do
     request =
@@ -175,7 +175,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:ok, DocuSign.Model.ConnectLog.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_log_get_connect_log(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec connect_log_get_connect_log(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ConnectLog.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -216,7 +216,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:ok, DocuSign.Model.ConnectLogs.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_log_get_connect_logs(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_log_get_connect_logs(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectLogs.t()}
           | {:error, Tesla.Env.t()}
@@ -257,7 +257,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:ok, DocuSign.Model.ConnectFailureResults.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec connect_publish_put_connect_retry(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec connect_publish_put_connect_retry(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ConnectFailureResults.t()}
           | {:error, Tesla.Env.t()}
@@ -299,7 +299,7 @@ defmodule DocuSign.Api.ConnectEvents do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec connect_publish_put_connect_retry_by_envelope(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/contacts.ex
+++ b/lib/docusign/api/contacts.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.Contacts do
   - `{:ok, DocuSign.Model.ContactUpdateResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec contacts_delete_contact_with_id(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec contacts_delete_contact_with_id(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ContactUpdateResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -64,7 +64,7 @@ defmodule DocuSign.Api.Contacts do
   - `{:ok, DocuSign.Model.ContactUpdateResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec contacts_delete_contacts(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec contacts_delete_contacts(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ContactUpdateResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -105,7 +105,7 @@ defmodule DocuSign.Api.Contacts do
   - `{:ok, DocuSign.Model.ContactGetResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec contacts_get_contact_by_id(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec contacts_get_contact_by_id(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ContactGetResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -145,7 +145,7 @@ defmodule DocuSign.Api.Contacts do
   - `{:ok, DocuSign.Model.ContactUpdateResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec contacts_post_contacts(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec contacts_post_contacts(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ContactUpdateResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -186,7 +186,7 @@ defmodule DocuSign.Api.Contacts do
   - `{:ok, DocuSign.Model.ContactUpdateResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec contacts_put_contacts(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec contacts_put_contacts(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ContactUpdateResponse.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/custom_tabs.ex
+++ b/lib/docusign/api/custom_tabs.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.CustomTabs do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tab_delete_custom_tab(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec tab_delete_custom_tab(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def tab_delete_custom_tab(connection, account_id, custom_tab_id, _opts \\ []) do
     request =
@@ -62,7 +62,7 @@ defmodule DocuSign.Api.CustomTabs do
   - `{:ok, DocuSign.Model.TabMetadata.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tab_get_custom_tab(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec tab_get_custom_tab(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TabMetadata.t()}
           | {:error, Tesla.Env.t()}
@@ -98,7 +98,7 @@ defmodule DocuSign.Api.CustomTabs do
   - `{:ok, DocuSign.Model.TabMetadata.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tab_put_custom_tab(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec tab_put_custom_tab(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TabMetadata.t()}
           | {:error, Tesla.Env.t()}
@@ -139,7 +139,7 @@ defmodule DocuSign.Api.CustomTabs do
   - `{:ok, DocuSign.Model.TabMetadataList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_get_tab_definitions(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec tabs_get_tab_definitions(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, TabMetadataList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -179,7 +179,7 @@ defmodule DocuSign.Api.CustomTabs do
   - `{:ok, DocuSign.Model.TabMetadata.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_post_tab_definitions(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec tabs_post_tab_definitions(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TabMetadata.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/document_generation.ex
+++ b/lib/docusign/api/document_generation.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.DocumentGeneration do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec doc_gen_form_fields_get_envelope_doc_gen_form_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -71,7 +71,7 @@ defmodule DocuSign.Api.DocumentGeneration do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec doc_gen_form_fields_put_envelope_doc_gen_form_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/document_responsive_html_preview.ex
+++ b/lib/docusign/api/document_responsive_html_preview.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.DocumentResponsiveHtmlPreview do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_post_document_responsive_html_preview(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/e_note_configurations.ex
+++ b/lib/docusign/api/e_note_configurations.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.Api.ENoteConfigurations do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec e_note_configuration_delete_e_note_configuration(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) :: {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
@@ -60,7 +60,7 @@ defmodule DocuSign.Api.ENoteConfigurations do
   - `{:ok, DocuSign.Model.ENoteConfiguration.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec e_note_configuration_get_e_note_configuration(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec e_note_configuration_get_e_note_configuration(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ENoteConfiguration.t()}
           | {:error, Tesla.Env.t()}
@@ -94,7 +94,7 @@ defmodule DocuSign.Api.ENoteConfigurations do
   - `{:ok, DocuSign.Model.ENoteConfiguration.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec e_note_configuration_put_e_note_configuration(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec e_note_configuration_put_e_note_configuration(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ENoteConfiguration.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_attachments.ex
+++ b/lib/docusign/api/envelope_attachments.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.EnvelopeAttachments do
   - `{:ok, DocuSign.Model.EnvelopeAttachmentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec attachments_delete_attachments(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec attachments_delete_attachments(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeAttachmentsResult.t()}
           | {:error, Tesla.Env.t()}
@@ -71,7 +71,7 @@ defmodule DocuSign.Api.EnvelopeAttachments do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec attachments_get_attachment(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -108,7 +108,7 @@ defmodule DocuSign.Api.EnvelopeAttachments do
   - `{:ok, DocuSign.Model.EnvelopeAttachmentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec attachments_get_attachments(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec attachments_get_attachments(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeAttachmentsResult.t()}
           | {:error, Tesla.Env.t()}
@@ -146,7 +146,7 @@ defmodule DocuSign.Api.EnvelopeAttachments do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec attachments_put_attachment(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -193,7 +193,7 @@ defmodule DocuSign.Api.EnvelopeAttachments do
   - `{:ok, DocuSign.Model.EnvelopeAttachmentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec attachments_put_attachments(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec attachments_put_attachments(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeAttachmentsResult.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_consumer_disclosures.ex
+++ b/lib/docusign/api/envelope_consumer_disclosures.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.EnvelopeConsumerDisclosures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec consumer_disclosure_get_consumer_disclosure_envelope_id_recipient_id(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -86,7 +86,7 @@ defmodule DocuSign.Api.EnvelopeConsumerDisclosures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec consumer_disclosure_get_consumer_disclosure_envelope_id_recipient_id_lang_code(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/envelope_custom_fields.ex
+++ b/lib/docusign/api/envelope_custom_fields.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.EnvelopeCustomFields do
   - `{:ok, DocuSign.Model.EnvelopeCustomFields.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec custom_fields_delete_custom_fields(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec custom_fields_delete_custom_fields(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeCustomFields.t()}
           | {:error, Tesla.Env.t()}
@@ -70,7 +70,7 @@ defmodule DocuSign.Api.EnvelopeCustomFields do
   - `{:ok, DocuSign.Model.CustomFieldsEnvelope.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec custom_fields_get_custom_fields(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec custom_fields_get_custom_fields(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, CustomFieldsEnvelope.t()}
           | {:error, Tesla.Env.t()}
@@ -106,7 +106,7 @@ defmodule DocuSign.Api.EnvelopeCustomFields do
   - `{:ok, DocuSign.Model.EnvelopeCustomFields.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec custom_fields_post_custom_fields(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec custom_fields_post_custom_fields(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeCustomFields.t()}
           | {:error, Tesla.Env.t()}
@@ -148,7 +148,7 @@ defmodule DocuSign.Api.EnvelopeCustomFields do
   - `{:ok, DocuSign.Model.EnvelopeCustomFields.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec custom_fields_put_custom_fields(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec custom_fields_put_custom_fields(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeCustomFields.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_document_fields.ex
+++ b/lib/docusign/api/envelope_document_fields.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.EnvelopeDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_delete_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -78,7 +78,7 @@ defmodule DocuSign.Api.EnvelopeDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_get_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -121,7 +121,7 @@ defmodule DocuSign.Api.EnvelopeDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_post_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -170,7 +170,7 @@ defmodule DocuSign.Api.EnvelopeDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_put_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/envelope_document_html_definitions.ex
+++ b/lib/docusign/api/envelope_document_html_definitions.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.EnvelopeDocumentHtmlDefinitions do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_get_envelope_document_html_definitions(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/envelope_document_tabs.ex
+++ b/lib/docusign/api/envelope_document_tabs.ex
@@ -32,7 +32,7 @@ defmodule DocuSign.Api.EnvelopeDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_delete_document_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.EnvelopeDocumentTabs do
   - `{:ok, DocuSign.Model.EnvelopeDocumentTabs.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_get_document_tabs(Tesla.Env.client(), String.t(), String.t(), String.t(), keyword()) ::
+  @spec tabs_get_document_tabs(DocuSign.Connection.t(), String.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeDocumentTabs.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -124,7 +124,7 @@ defmodule DocuSign.Api.EnvelopeDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_get_page_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -167,7 +167,7 @@ defmodule DocuSign.Api.EnvelopeDocumentTabs do
   - `{:ok, DocuSign.Model.Tabs.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_post_document_tabs(Tesla.Env.client(), String.t(), String.t(), String.t(), keyword()) ::
+  @spec tabs_post_document_tabs(DocuSign.Connection.t(), String.t(), String.t(), String.t(), keyword()) ::
           {:ok, Tabs.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -210,7 +210,7 @@ defmodule DocuSign.Api.EnvelopeDocumentTabs do
   - `{:ok, DocuSign.Model.Tabs.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_put_document_tabs(Tesla.Env.client(), String.t(), String.t(), String.t(), keyword()) ::
+  @spec tabs_put_document_tabs(DocuSign.Connection.t(), String.t(), String.t(), String.t(), keyword()) ::
           {:ok, Tabs.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_document_visibility.ex
+++ b/lib/docusign/api/envelope_document_visibility.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.EnvelopeDocumentVisibility do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_recipient_document_visibility(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -73,7 +73,7 @@ defmodule DocuSign.Api.EnvelopeDocumentVisibility do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_recipient_document_visibility(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -121,7 +121,7 @@ defmodule DocuSign.Api.EnvelopeDocumentVisibility do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_recipients_document_visibility(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/envelope_documents.ex
+++ b/lib/docusign/api/envelope_documents.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.EnvelopeDocuments do
   - `{:ok, DocuSign.Model.EnvelopeDocumentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_delete_documents(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec documents_delete_documents(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeDocumentsResult.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.EnvelopeDocuments do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_get_document(Tesla.Env.client(), String.t(), String.t(), String.t(), keyword()) ::
+  @spec documents_get_document(DocuSign.Connection.t(), String.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()} | {:ok, String.t()} | {:error, Tesla.Env.t()}
   def documents_get_document(connection, account_id, document_id, envelope_id, opts \\ []) do
     optional_params = %{
@@ -132,7 +132,7 @@ defmodule DocuSign.Api.EnvelopeDocuments do
   - `{:ok, DocuSign.Model.EnvelopeDocumentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_get_documents(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec documents_get_documents(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeDocumentsResult.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -180,7 +180,7 @@ defmodule DocuSign.Api.EnvelopeDocuments do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec documents_put_document(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -223,7 +223,7 @@ defmodule DocuSign.Api.EnvelopeDocuments do
   - `{:ok, DocuSign.Model.EnvelopeDocumentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_put_documents(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec documents_put_documents(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeDocumentsResult.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_email_settings.ex
+++ b/lib/docusign/api/envelope_email_settings.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.EnvelopeEmailSettings do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec email_settings_delete_email_settings(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -68,7 +68,7 @@ defmodule DocuSign.Api.EnvelopeEmailSettings do
   - `{:ok, DocuSign.Model.EmailSettings.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec email_settings_get_email_settings(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec email_settings_get_email_settings(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EmailSettings.t()}
           | {:error, Tesla.Env.t()}
@@ -104,7 +104,7 @@ defmodule DocuSign.Api.EnvelopeEmailSettings do
   - `{:ok, DocuSign.Model.EmailSettings.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec email_settings_post_email_settings(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec email_settings_post_email_settings(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EmailSettings.t()}
           | {:error, Tesla.Env.t()}
@@ -146,7 +146,7 @@ defmodule DocuSign.Api.EnvelopeEmailSettings do
   - `{:ok, DocuSign.Model.EmailSettings.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec email_settings_put_email_settings(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec email_settings_put_email_settings(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EmailSettings.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_form_data.ex
+++ b/lib/docusign/api/envelope_form_data.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.EnvelopeFormData do
   - `{:ok, DocuSign.Model.EnvelopeFormData.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec form_data_get_form_data(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec form_data_get_form_data(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeFormData.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_html_definitions.ex
+++ b/lib/docusign/api/envelope_html_definitions.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.EnvelopeHtmlDefinitions do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_get_envelope_html_definitions(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/envelope_locks.ex
+++ b/lib/docusign/api/envelope_locks.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.EnvelopeLocks do
   - `{:ok, DocuSign.Model.EnvelopeLocks.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_delete_envelope_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_delete_envelope_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeLocks.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -63,7 +63,7 @@ defmodule DocuSign.Api.EnvelopeLocks do
   - `{:ok, DocuSign.Model.EnvelopeLocks.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_get_envelope_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_get_envelope_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeLocks.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -99,7 +99,7 @@ defmodule DocuSign.Api.EnvelopeLocks do
   - `{:ok, DocuSign.Model.EnvelopeLocks.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_post_envelope_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_post_envelope_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeLocks.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -141,7 +141,7 @@ defmodule DocuSign.Api.EnvelopeLocks do
   - `{:ok, DocuSign.Model.EnvelopeLocks.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_put_envelope_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_put_envelope_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeLocks.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_publish.ex
+++ b/lib/docusign/api/envelope_publish.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.EnvelopePublish do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec historical_envelope_publish_post_historical_envelope_publish_transaction(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::

--- a/lib/docusign/api/envelope_recipient_tabs.ex
+++ b/lib/docusign/api/envelope_recipient_tabs.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.EnvelopeRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_delete_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.EnvelopeRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -129,7 +129,7 @@ defmodule DocuSign.Api.EnvelopeRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_post_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -178,7 +178,7 @@ defmodule DocuSign.Api.EnvelopeRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/envelope_recipients.ex
+++ b/lib/docusign/api/envelope_recipients.ex
@@ -33,7 +33,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_delete_recipient(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -74,7 +74,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:ok, DocuSign.Model.EnvelopeRecipients.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_delete_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_delete_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeRecipients.t()}
           | {:error, Tesla.Env.t()}
@@ -118,7 +118,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:ok, DocuSign.Model.EnvelopeRecipients.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_get_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_get_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeRecipients.t()}
           | {:error, Tesla.Env.t()}
@@ -164,7 +164,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_post_recipient_proof_file_resource_token(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -212,7 +212,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:ok, DocuSign.Model.EnvelopeRecipients.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_post_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_post_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeRecipients.t()}
           | {:error, Tesla.Env.t()}
@@ -258,7 +258,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:ok, DocuSign.Model.RecipientsUpdateSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_put_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_put_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, RecipientsUpdateSummary.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -304,7 +304,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec views_post_envelope_recipient_preview(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -351,7 +351,7 @@ defmodule DocuSign.Api.EnvelopeRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec views_post_recipient_manual_review_view(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/envelope_templates.ex
+++ b/lib/docusign/api/envelope_templates.ex
@@ -32,7 +32,7 @@ defmodule DocuSign.Api.EnvelopeTemplates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec templates_delete_document_templates(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -73,7 +73,7 @@ defmodule DocuSign.Api.EnvelopeTemplates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec templates_get_document_templates(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -119,7 +119,7 @@ defmodule DocuSign.Api.EnvelopeTemplates do
   - `{:ok, DocuSign.Model.TemplateInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_get_envelope_templates(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec templates_get_envelope_templates(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TemplateInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -163,7 +163,7 @@ defmodule DocuSign.Api.EnvelopeTemplates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec templates_post_document_templates(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -212,7 +212,7 @@ defmodule DocuSign.Api.EnvelopeTemplates do
   - `{:ok, DocuSign.Model.DocumentTemplateList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_post_envelope_templates(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec templates_post_envelope_templates(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, DocumentTemplateList.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_transfer_rules.ex
+++ b/lib/docusign/api/envelope_transfer_rules.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.EnvelopeTransferRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_transfer_rules_delete_envelope_transfer_rules(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -73,7 +73,7 @@ defmodule DocuSign.Api.EnvelopeTransferRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_transfer_rules_get_envelope_transfer_rules(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -118,7 +118,7 @@ defmodule DocuSign.Api.EnvelopeTransferRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_transfer_rules_post_envelope_transfer_rules(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::
@@ -164,7 +164,7 @@ defmodule DocuSign.Api.EnvelopeTransferRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_transfer_rules_put_envelope_transfer_rule(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -210,7 +210,7 @@ defmodule DocuSign.Api.EnvelopeTransferRules do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_transfer_rules_put_envelope_transfer_rules(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::

--- a/lib/docusign/api/envelope_views.ex
+++ b/lib/docusign/api/envelope_views.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_delete_envelope_correct_view(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec views_delete_envelope_correct_view(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def views_delete_envelope_correct_view(connection, account_id, envelope_id, opts \\ []) do
     optional_params = %{
@@ -68,7 +68,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:ok, DocuSign.Model.EnvelopeViews.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_post_account_console_view(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec views_post_account_console_view(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, EnvelopeViews.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -110,7 +110,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:ok, DocuSign.Model.EnvelopeViews.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_post_envelope_correct_view(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec views_post_envelope_correct_view(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeViews.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -152,7 +152,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:ok, DocuSign.Model.EnvelopeViews.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_post_envelope_edit_view(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec views_post_envelope_edit_view(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeViews.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -195,7 +195,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec views_post_envelope_recipient_shared_view(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -241,7 +241,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:ok, DocuSign.Model.EnvelopeViews.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_post_envelope_recipient_view(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec views_post_envelope_recipient_view(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeViews.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -283,7 +283,7 @@ defmodule DocuSign.Api.EnvelopeViews do
   - `{:ok, DocuSign.Model.EnvelopeViews.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_post_envelope_sender_view(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec views_post_envelope_sender_view(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeViews.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/envelope_workflow_definition.ex
+++ b/lib/docusign/api/envelope_workflow_definition.ex
@@ -32,7 +32,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_definition_v2_delete_envelope_workflow_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -74,7 +74,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_definition_v2_get_envelope_workflow_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -115,7 +115,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_definition_v2_put_envelope_workflow_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -162,7 +162,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_delayed_routing_delete_envelope_delayed_routing_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -207,7 +207,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_delayed_routing_get_envelope_delayed_routing_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -256,7 +256,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_delayed_routing_put_envelope_delayed_routing_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -309,7 +309,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_scheduled_sending_delete_envelope_scheduled_sending_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -351,7 +351,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_scheduled_sending_get_envelope_scheduled_sending_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -397,7 +397,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_scheduled_sending_put_envelope_scheduled_sending_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -449,7 +449,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_step_delete_envelope_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -494,7 +494,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_step_get_envelope_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -542,7 +542,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_step_post_envelope_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -590,7 +590,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec envelope_workflow_step_put_envelope_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -643,7 +643,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_definition_delete_template_workflow_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -680,7 +680,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_definition_get_template_workflow_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -721,7 +721,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_definition_put_template_workflow_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -768,7 +768,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_delayed_routing_delete_template_delayed_routing_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -813,7 +813,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_delayed_routing_get_template_delayed_routing_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -862,7 +862,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_delayed_routing_put_template_delayed_routing_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -915,7 +915,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_scheduled_sending_delete_template_scheduled_sending_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -957,7 +957,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_scheduled_sending_get_template_scheduled_sending_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -1002,7 +1002,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_scheduled_sending_put_template_scheduled_sending_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -1054,7 +1054,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_step_delete_template_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -1099,7 +1099,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_step_get_template_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -1147,7 +1147,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_step_post_template_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -1195,7 +1195,7 @@ defmodule DocuSign.Api.EnvelopeWorkflowDefinition do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec template_workflow_step_put_template_workflow_step_definition(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/envelopes.ex
+++ b/lib/docusign/api/envelopes.ex
@@ -35,7 +35,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.EnvelopeAuditEventResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec audit_events_get_audit_events(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec audit_events_get_audit_events(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeAuditEventResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -73,7 +73,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.Envelope.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec envelopes_get_envelope(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec envelopes_get_envelope(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, Envelope.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -145,7 +145,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.EnvelopesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec envelopes_get_envelopes(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec envelopes_get_envelopes(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopesInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -219,7 +219,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.EnvelopeSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec envelopes_post_envelopes(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec envelopes_post_envelopes(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeSummary.t()}
           | {:error, Tesla.Env.t()}
@@ -268,7 +268,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.EnvelopeUpdateSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec envelopes_put_envelope(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec envelopes_put_envelope(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopeUpdateSummary.t()}
           | {:error, Tesla.Env.t()}
@@ -324,7 +324,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.EnvelopesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec envelopes_put_status(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec envelopes_put_status(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, EnvelopesInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -378,7 +378,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec notification_get_envelopes_envelope_id_notification(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -419,7 +419,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec notification_put_envelopes_envelope_id_notification(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -467,7 +467,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_delete_page(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -512,7 +512,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_get_page_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -568,7 +568,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:ok, DocuSign.Model.PageImages.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec pages_get_page_images(Tesla.Env.client(), String.t(), String.t(), String.t(), keyword()) ::
+  @spec pages_get_page_images(DocuSign.Connection.t(), String.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PageImages.t()}
           | {:error, Tesla.Env.t()}
@@ -618,7 +618,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_put_page_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -667,7 +667,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_recipient_initials_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -711,7 +711,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_recipient_signature(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -754,7 +754,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_recipient_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -798,7 +798,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_recipient_initials_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -838,7 +838,7 @@ defmodule DocuSign.Api.Envelopes do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_recipient_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/favorite_templates.ex
+++ b/lib/docusign/api/favorite_templates.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.Api.FavoriteTemplates do
   - `{:ok, DocuSign.Model.FavoriteTemplatesInfo.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec favorite_templates_get_favorite_templates(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec favorite_templates_get_favorite_templates(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, FavoriteTemplatesInfo.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -62,7 +62,7 @@ defmodule DocuSign.Api.FavoriteTemplates do
   - `{:ok, DocuSign.Model.FavoriteTemplatesInfo.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec favorite_templates_put_favorite_template(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec favorite_templates_put_favorite_template(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, FavoriteTemplatesInfo.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -103,7 +103,7 @@ defmodule DocuSign.Api.FavoriteTemplates do
   - `{:ok, DocuSign.Model.FavoriteTemplatesInfo.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec favorite_templates_un_favorite_template(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec favorite_templates_un_favorite_template(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, FavoriteTemplatesInfo.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/folders.ex
+++ b/lib/docusign/api/folders.ex
@@ -38,7 +38,7 @@ defmodule DocuSign.Api.Folders do
   - `{:ok, DocuSign.Model.FolderItemsResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec folders_get_folder_items(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec folders_get_folder_items(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, FolderItemsResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -91,7 +91,7 @@ defmodule DocuSign.Api.Folders do
   - `{:ok, DocuSign.Model.FoldersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec folders_get_folders(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec folders_get_folders(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, FoldersResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -138,7 +138,7 @@ defmodule DocuSign.Api.Folders do
   - `{:ok, DocuSign.Model.FoldersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec folders_put_folder_by_id(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec folders_put_folder_by_id(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, FoldersResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -188,7 +188,7 @@ defmodule DocuSign.Api.Folders do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec search_folders_get_search_folder_contents(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/group_brands.ex
+++ b/lib/docusign/api/group_brands.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.GroupBrands do
   - `{:ok, DocuSign.Model.GroupBrands.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brands_delete_group_brands(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brands_delete_group_brands(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupBrands.t()}
           | {:error, Tesla.Env.t()}
@@ -69,7 +69,7 @@ defmodule DocuSign.Api.GroupBrands do
   - `{:ok, DocuSign.Model.GroupBrands.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brands_get_group_brands(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brands_get_group_brands(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupBrands.t()}
           | {:error, Tesla.Env.t()}
@@ -105,7 +105,7 @@ defmodule DocuSign.Api.GroupBrands do
   - `{:ok, DocuSign.Model.GroupBrands.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec brands_put_group_brands(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec brands_put_group_brands(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupBrands.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/group_users.ex
+++ b/lib/docusign/api/group_users.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.GroupUsers do
   - `{:ok, DocuSign.Model.UsersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_delete_group_users(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec groups_delete_group_users(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UsersResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -71,7 +71,7 @@ defmodule DocuSign.Api.GroupUsers do
   - `{:ok, DocuSign.Model.UsersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_get_group_users(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec groups_get_group_users(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UsersResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -113,7 +113,7 @@ defmodule DocuSign.Api.GroupUsers do
   - `{:ok, DocuSign.Model.UsersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_put_group_users(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec groups_put_group_users(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UsersResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/groups.ex
+++ b/lib/docusign/api/groups.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.Groups do
   - `{:ok, DocuSign.Model.GroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_delete_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec groups_delete_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -72,7 +72,7 @@ defmodule DocuSign.Api.Groups do
   - `{:ok, DocuSign.Model.GroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_get_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec groups_get_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -116,7 +116,7 @@ defmodule DocuSign.Api.Groups do
   - `{:ok, DocuSign.Model.GroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_post_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec groups_post_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -157,7 +157,7 @@ defmodule DocuSign.Api.Groups do
   - `{:ok, DocuSign.Model.GroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec groups_put_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec groups_put_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, GroupInformation.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/identity_verifications.ex
+++ b/lib/docusign/api/identity_verifications.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.IdentityVerifications do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec account_identity_verification_get_account_identity_verification(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::

--- a/lib/docusign/api/invoices.ex
+++ b/lib/docusign/api/invoices.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.Invoices do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec billing_invoices_get_billing_invoice(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -71,7 +71,7 @@ defmodule DocuSign.Api.Invoices do
   - `{:ok, DocuSign.Model.BillingInvoicesResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_invoices_get_billing_invoices(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_invoices_get_billing_invoices(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BillingInvoicesResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -111,7 +111,7 @@ defmodule DocuSign.Api.Invoices do
   - `{:ok, DocuSign.Model.BillingInvoicesSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_invoices_get_billing_invoices_past_due(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_invoices_get_billing_invoices_past_due(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BillingInvoicesSummary.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/notary.ex
+++ b/lib/docusign/api/notary.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.Notary do
   - `{:ok, DocuSign.Model.NotaryResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_get_notary(Tesla.Env.client(), keyword()) ::
+  @spec notary_get_notary(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NotaryResult.t()}
           | {:error, Tesla.Env.t()}
@@ -67,7 +67,7 @@ defmodule DocuSign.Api.Notary do
   - `{:ok, DocuSign.Model.Notary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_post_notary(Tesla.Env.client(), keyword()) ::
+  @spec notary_post_notary(DocuSign.Connection.t(), keyword()) ::
           {:ok, Notary.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -107,7 +107,7 @@ defmodule DocuSign.Api.Notary do
   - `{:ok, DocuSign.Model.Notary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_put_notary(Tesla.Env.client(), keyword()) ::
+  @spec notary_put_notary(DocuSign.Connection.t(), keyword()) ::
           {:ok, Notary.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/notary_journals.ex
+++ b/lib/docusign/api/notary_journals.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.NotaryJournals do
   - `{:ok, DocuSign.Model.NotaryJournalList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_journals_get_notary_journals(Tesla.Env.client(), keyword()) ::
+  @spec notary_journals_get_notary_journals(DocuSign.Connection.t(), keyword()) ::
           {:ok, NotaryJournalList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/notary_jurisdiction.ex
+++ b/lib/docusign/api/notary_jurisdiction.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.NotaryJurisdiction do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_jurisdictions_delete_notary_jurisdiction(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec notary_jurisdictions_delete_notary_jurisdiction(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def notary_jurisdictions_delete_notary_jurisdiction(connection, jurisdiction_id, _opts \\ []) do
     request =
@@ -60,7 +60,7 @@ defmodule DocuSign.Api.NotaryJurisdiction do
   - `{:ok, DocuSign.Model.NotaryJurisdiction.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_jurisdictions_get_notary_jurisdiction(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec notary_jurisdictions_get_notary_jurisdiction(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NotaryJurisdiction.t()}
           | {:error, Tesla.Env.t()}
@@ -93,7 +93,7 @@ defmodule DocuSign.Api.NotaryJurisdiction do
   - `{:ok, DocuSign.Model.NotaryJurisdictionList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_jurisdictions_get_notary_jurisdictions(Tesla.Env.client(), keyword()) ::
+  @spec notary_jurisdictions_get_notary_jurisdictions(DocuSign.Connection.t(), keyword()) ::
           {:ok, NotaryJurisdictionList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -127,7 +127,7 @@ defmodule DocuSign.Api.NotaryJurisdiction do
   - `{:ok, DocuSign.Model.NotaryJurisdiction.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_jurisdictions_post_notary_jurisdictions(Tesla.Env.client(), keyword()) ::
+  @spec notary_jurisdictions_post_notary_jurisdictions(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NotaryJurisdiction.t()}
           | {:error, Tesla.Env.t()}
@@ -168,7 +168,7 @@ defmodule DocuSign.Api.NotaryJurisdiction do
   - `{:ok, DocuSign.Model.NotaryJurisdiction.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec notary_jurisdictions_put_notary_jurisdiction(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec notary_jurisdictions_put_notary_jurisdiction(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NotaryJurisdiction.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/payment_gateway_accounts.ex
+++ b/lib/docusign/api/payment_gateway_accounts.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.PaymentGatewayAccounts do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec payment_gateway_accounts_get_all_payment_gateway_accounts(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           keyword()
         ) ::

--- a/lib/docusign/api/payments.ex
+++ b/lib/docusign/api/payments.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.Payments do
   - `{:ok, DocuSign.Model.BillingPaymentItem.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_payments_get_payment(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec billing_payments_get_payment(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, BillingPaymentItem.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -66,7 +66,7 @@ defmodule DocuSign.Api.Payments do
   - `{:ok, DocuSign.Model.BillingPaymentsResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_payments_get_payment_list(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_payments_get_payment_list(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, BillingPaymentsResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -107,7 +107,7 @@ defmodule DocuSign.Api.Payments do
   - `{:ok, DocuSign.Model.BillingPaymentResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec billing_payments_post_payment(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec billing_payments_post_payment(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, BillingPaymentResponse.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/power_form_data.ex
+++ b/lib/docusign/api/power_form_data.ex
@@ -32,7 +32,7 @@ defmodule DocuSign.Api.PowerFormData do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec power_forms_get_power_form_form_data(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/power_forms.ex
+++ b/lib/docusign/api/power_forms.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_delete_power_form(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec power_forms_delete_power_form(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def power_forms_delete_power_form(connection, account_id, power_form_id, _opts \\ []) do
     request =
@@ -63,7 +63,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, DocuSign.Model.PowerFormsResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_delete_power_forms_list(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec power_forms_delete_power_forms_list(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, PowerFormsResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -103,7 +103,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, DocuSign.Model.PowerForm.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_get_power_form(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec power_forms_get_power_form(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PowerForm.t()}
           | {:error, Tesla.Env.t()}
@@ -145,7 +145,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, DocuSign.Model.PowerFormsResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_get_power_forms_list(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec power_forms_get_power_forms_list(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, PowerFormsResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -192,7 +192,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, DocuSign.Model.PowerFormSendersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_get_power_forms_senders(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec power_forms_get_power_forms_senders(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PowerFormSendersResponse.t()}
           | {:error, Tesla.Env.t()}
@@ -232,7 +232,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, DocuSign.Model.PowerForm.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_post_power_form(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec power_forms_post_power_form(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PowerForm.t()}
           | {:error, Tesla.Env.t()}
@@ -274,7 +274,7 @@ defmodule DocuSign.Api.PowerForms do
   - `{:ok, DocuSign.Model.PowerForm.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec power_forms_put_power_form(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec power_forms_put_power_form(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, PowerForm.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/request_logs.ex
+++ b/lib/docusign/api/request_logs.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.Api.RequestLogs do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec a_pi_request_log_delete_request_logs(Tesla.Env.client(), keyword()) ::
+  @spec a_pi_request_log_delete_request_logs(DocuSign.Connection.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def a_pi_request_log_delete_request_logs(connection, _opts \\ []) do
     request =
@@ -59,7 +59,7 @@ defmodule DocuSign.Api.RequestLogs do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec a_pi_request_log_get_request_log(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec a_pi_request_log_get_request_log(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()} | {:ok, String.t()} | {:error, Tesla.Env.t()}
   def a_pi_request_log_get_request_log(connection, request_log_id, _opts \\ []) do
     request =
@@ -90,7 +90,7 @@ defmodule DocuSign.Api.RequestLogs do
   - `{:ok, DocuSign.Model.DiagnosticsSettingsInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec a_pi_request_log_get_request_log_settings(Tesla.Env.client(), keyword()) ::
+  @spec a_pi_request_log_get_request_log_settings(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, DiagnosticsSettingsInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -124,7 +124,7 @@ defmodule DocuSign.Api.RequestLogs do
   - `{:ok, DocuSign.Model.ApiRequestLogsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec a_pi_request_log_get_request_logs(Tesla.Env.client(), keyword()) ::
+  @spec a_pi_request_log_get_request_logs(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ApiRequestLogsResult.t()}
           | {:error, Tesla.Env.t()}
@@ -163,7 +163,7 @@ defmodule DocuSign.Api.RequestLogs do
   - `{:ok, DocuSign.Model.DiagnosticsSettingsInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec a_pi_request_log_put_request_log_settings(Tesla.Env.client(), keyword()) ::
+  @spec a_pi_request_log_put_request_log_settings(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, DiagnosticsSettingsInformation.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/resources.ex
+++ b/lib/docusign/api/resources.ex
@@ -26,7 +26,7 @@ defmodule DocuSign.Api.Resources do
   - `{:ok, DocuSign.Model.ResourceInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec service_information_get_resource_information(Tesla.Env.client(), keyword()) ::
+  @spec service_information_get_resource_information(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ResourceInformation.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/responsive_html_preview.ex
+++ b/lib/docusign/api/responsive_html_preview.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.ResponsiveHtmlPreview do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_post_responsive_html_preview(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/services.ex
+++ b/lib/docusign/api/services.ex
@@ -26,7 +26,7 @@ defmodule DocuSign.Api.Services do
   - `{:ok, DocuSign.Model.ServiceInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec service_information_get_service_information(Tesla.Env.client(), keyword()) ::
+  @spec service_information_get_service_information(DocuSign.Connection.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, ServiceInformation.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/signing_group_users.ex
+++ b/lib/docusign/api/signing_group_users.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.SigningGroupUsers do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec signing_groups_delete_signing_group_users(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -75,7 +75,7 @@ defmodule DocuSign.Api.SigningGroupUsers do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec signing_groups_get_signing_group_users(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -116,7 +116,7 @@ defmodule DocuSign.Api.SigningGroupUsers do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec signing_groups_put_signing_group_users(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/signing_groups.ex
+++ b/lib/docusign/api/signing_groups.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.SigningGroups do
   - `{:ok, DocuSign.Model.SigningGroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec signing_groups_delete_signing_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec signing_groups_delete_signing_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, SigningGroupInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -69,7 +69,7 @@ defmodule DocuSign.Api.SigningGroups do
   - `{:ok, DocuSign.Model.SigningGroup.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec signing_groups_get_signing_group(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec signing_groups_get_signing_group(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, SigningGroup.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -105,7 +105,7 @@ defmodule DocuSign.Api.SigningGroups do
   - `{:ok, DocuSign.Model.SigningGroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec signing_groups_get_signing_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec signing_groups_get_signing_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, SigningGroupInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -146,7 +146,7 @@ defmodule DocuSign.Api.SigningGroups do
   - `{:ok, DocuSign.Model.SigningGroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec signing_groups_post_signing_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec signing_groups_post_signing_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, SigningGroupInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -188,7 +188,7 @@ defmodule DocuSign.Api.SigningGroups do
   - `{:ok, DocuSign.Model.SigningGroup.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec signing_groups_put_signing_group(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec signing_groups_put_signing_group(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, SigningGroup.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -229,7 +229,7 @@ defmodule DocuSign.Api.SigningGroups do
   - `{:ok, DocuSign.Model.SigningGroupInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec signing_groups_put_signing_groups(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec signing_groups_put_signing_groups(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, SigningGroupInformation.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/tabs_blob.ex
+++ b/lib/docusign/api/tabs_blob.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.Api.TabsBlob do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_blob_get_tabs_blob(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec tabs_blob_get_tabs_blob(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def tabs_blob_get_tabs_blob(connection, account_id, envelope_id, _opts \\ []) do
     request =
@@ -60,7 +60,7 @@ defmodule DocuSign.Api.TabsBlob do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec tabs_blob_put_tabs_blob(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec tabs_blob_put_tabs_blob(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def tabs_blob_put_tabs_blob(connection, account_id, envelope_id, _opts \\ []) do
     request =

--- a/lib/docusign/api/template_custom_fields.ex
+++ b/lib/docusign/api/template_custom_fields.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.TemplateCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec custom_fields_delete_template_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -75,7 +75,7 @@ defmodule DocuSign.Api.TemplateCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec custom_fields_get_template_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -116,7 +116,7 @@ defmodule DocuSign.Api.TemplateCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec custom_fields_post_template_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -163,7 +163,7 @@ defmodule DocuSign.Api.TemplateCustomFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec custom_fields_put_template_custom_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/template_document_fields.ex
+++ b/lib/docusign/api/template_document_fields.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.TemplateDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_delete_template_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -78,7 +78,7 @@ defmodule DocuSign.Api.TemplateDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_get_template_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -121,7 +121,7 @@ defmodule DocuSign.Api.TemplateDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_post_template_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -170,7 +170,7 @@ defmodule DocuSign.Api.TemplateDocumentFields do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec document_fields_put_template_document_fields(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/template_document_html_definitions.ex
+++ b/lib/docusign/api/template_document_html_definitions.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.TemplateDocumentHtmlDefinitions do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_get_template_document_html_definitions(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/template_document_responsive_html_preview.ex
+++ b/lib/docusign/api/template_document_responsive_html_preview.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.TemplateDocumentResponsiveHtmlPreview do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_post_template_document_responsive_html_preview(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/template_document_tabs.ex
+++ b/lib/docusign/api/template_document_tabs.ex
@@ -32,7 +32,7 @@ defmodule DocuSign.Api.TemplateDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_delete_template_document_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.TemplateDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_get_template_document_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -128,7 +128,7 @@ defmodule DocuSign.Api.TemplateDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_get_template_page_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -172,7 +172,7 @@ defmodule DocuSign.Api.TemplateDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_post_template_document_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -221,7 +221,7 @@ defmodule DocuSign.Api.TemplateDocumentTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec tabs_put_template_document_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/template_document_visibility.ex
+++ b/lib/docusign/api/template_document_visibility.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.TemplateDocumentVisibility do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_template_recipient_document_visibility(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.TemplateDocumentVisibility do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_template_recipient_document_visibility(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -134,7 +134,7 @@ defmodule DocuSign.Api.TemplateDocumentVisibility do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_template_recipients_document_visibility(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/template_documents.ex
+++ b/lib/docusign/api/template_documents.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.TemplateDocuments do
   - `{:ok, DocuSign.Model.TemplateDocumentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_delete_template_documents(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec documents_delete_template_documents(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TemplateDocumentsResult.t()}
           | {:error, Tesla.Env.t()}
@@ -75,7 +75,7 @@ defmodule DocuSign.Api.TemplateDocuments do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec documents_get_template_document(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -120,7 +120,7 @@ defmodule DocuSign.Api.TemplateDocuments do
   - `{:ok, DocuSign.Model.TemplateDocumentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_get_template_documents(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec documents_get_template_documents(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TemplateDocumentsResult.t()}
           | {:error, Tesla.Env.t()}
@@ -164,7 +164,7 @@ defmodule DocuSign.Api.TemplateDocuments do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec documents_put_template_document(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -212,7 +212,7 @@ defmodule DocuSign.Api.TemplateDocuments do
   - `{:ok, DocuSign.Model.TemplateDocumentsResult.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec documents_put_template_documents(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec documents_put_template_documents(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, TemplateDocumentsResult.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/template_html_definitions.ex
+++ b/lib/docusign/api/template_html_definitions.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.TemplateHtmlDefinitions do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_get_template_html_definitions(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/template_locks.ex
+++ b/lib/docusign/api/template_locks.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.TemplateLocks do
   - `{:ok, DocuSign.Model.LockInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_delete_template_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_delete_template_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, LockInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -69,7 +69,7 @@ defmodule DocuSign.Api.TemplateLocks do
   - `{:ok, DocuSign.Model.LockInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_get_template_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_get_template_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, LockInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -105,7 +105,7 @@ defmodule DocuSign.Api.TemplateLocks do
   - `{:ok, DocuSign.Model.LockInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_post_template_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_post_template_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, LockInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -147,7 +147,7 @@ defmodule DocuSign.Api.TemplateLocks do
   - `{:ok, DocuSign.Model.LockInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec lock_put_template_lock(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec lock_put_template_lock(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, LockInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/template_recipient_tabs.ex
+++ b/lib/docusign/api/template_recipient_tabs.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.TemplateRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_delete_template_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.TemplateRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_get_template_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -129,7 +129,7 @@ defmodule DocuSign.Api.TemplateRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_post_template_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -178,7 +178,7 @@ defmodule DocuSign.Api.TemplateRecipientTabs do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_put_template_recipient_tabs(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/template_recipients.ex
+++ b/lib/docusign/api/template_recipients.ex
@@ -33,7 +33,7 @@ defmodule DocuSign.Api.TemplateRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_delete_template_recipient(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -80,7 +80,7 @@ defmodule DocuSign.Api.TemplateRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec recipients_delete_template_recipients(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -127,7 +127,7 @@ defmodule DocuSign.Api.TemplateRecipients do
   - `{:ok, DocuSign.Model.Recipients.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_get_template_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_get_template_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, Recipients.t()}
           | {:error, Tesla.Env.t()}
@@ -171,7 +171,7 @@ defmodule DocuSign.Api.TemplateRecipients do
   - `{:ok, DocuSign.Model.Recipients.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_post_template_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_post_template_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, Recipients.t()}
           | {:error, Tesla.Env.t()}
@@ -215,7 +215,7 @@ defmodule DocuSign.Api.TemplateRecipients do
   - `{:ok, DocuSign.Model.RecipientsUpdateSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec recipients_put_template_recipients(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec recipients_put_template_recipients(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, RecipientsUpdateSummary.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -259,7 +259,7 @@ defmodule DocuSign.Api.TemplateRecipients do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec views_post_template_recipient_preview(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/template_responsive_html_preview.ex
+++ b/lib/docusign/api/template_responsive_html_preview.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.TemplateResponsiveHtmlPreview do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec responsive_html_post_template_responsive_html_preview(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/template_views.ex
+++ b/lib/docusign/api/template_views.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.TemplateViews do
   - `{:ok, DocuSign.Model.ViewUrl.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec views_post_template_edit_view(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec views_post_template_edit_view(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ViewUrl.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/templates.ex
+++ b/lib/docusign/api/templates.ex
@@ -36,7 +36,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec notification_get_templates_template_id_notification(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -77,7 +77,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec notification_put_templates_template_id_notification(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -126,7 +126,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_delete_template_page(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -176,7 +176,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_get_template_page_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -233,7 +233,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_get_template_page_images(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -288,7 +288,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec pages_put_template_page_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -332,7 +332,7 @@ defmodule DocuSign.Api.Templates do
   - `{:ok, DocuSign.Model.TemplateAutoMatchList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_auto_match_put_templates(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec templates_auto_match_put_templates(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, TemplateAutoMatchList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -376,7 +376,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec templates_delete_template_part(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -422,7 +422,7 @@ defmodule DocuSign.Api.Templates do
   - `{:ok, DocuSign.Model.EnvelopeTemplate.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_get_template(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec templates_get_template(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, EnvelopeTemplate.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -484,7 +484,7 @@ defmodule DocuSign.Api.Templates do
   - `{:ok, DocuSign.Model.EnvelopeTemplateResults.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_get_templates(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec templates_get_templates(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, EnvelopeTemplateResults.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -546,7 +546,7 @@ defmodule DocuSign.Api.Templates do
   - `{:ok, DocuSign.Model.TemplateSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_post_templates(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec templates_post_templates(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, TemplateSummary.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -588,7 +588,7 @@ defmodule DocuSign.Api.Templates do
   - `{:ok, DocuSign.Model.TemplateUpdateSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_put_template(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec templates_put_template(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, TemplateUpdateSummary.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -632,7 +632,7 @@ defmodule DocuSign.Api.Templates do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec templates_put_template_part(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -676,7 +676,7 @@ defmodule DocuSign.Api.Templates do
   - `{:ok, DocuSign.Model.TemplateAutoMatchList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec templates_put_templates(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec templates_put_templates(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, TemplateAutoMatchList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/user_custom_settings.ex
+++ b/lib/docusign/api/user_custom_settings.ex
@@ -30,7 +30,7 @@ defmodule DocuSign.Api.UserCustomSettings do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_custom_settings_delete_custom_settings(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -75,7 +75,7 @@ defmodule DocuSign.Api.UserCustomSettings do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_custom_settings_get_custom_settings(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -116,7 +116,7 @@ defmodule DocuSign.Api.UserCustomSettings do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_custom_settings_put_custom_settings(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()

--- a/lib/docusign/api/user_profiles.ex
+++ b/lib/docusign/api/user_profiles.ex
@@ -28,7 +28,7 @@ defmodule DocuSign.Api.UserProfiles do
   - `{:ok, DocuSign.Model.UserProfile.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_profile_get_profile(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_profile_get_profile(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UserProfile.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -64,7 +64,7 @@ defmodule DocuSign.Api.UserProfiles do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_profile_put_profile(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_profile_put_profile(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def user_profile_put_profile(connection, account_id, user_id, opts \\ []) do
     optional_params = %{

--- a/lib/docusign/api/user_signatures.ex
+++ b/lib/docusign/api/user_signatures.ex
@@ -31,7 +31,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_delete_user_signature(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -71,7 +71,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_delete_user_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -121,7 +121,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_get_user_signature(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -165,7 +165,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_get_user_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -209,7 +209,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:ok, DocuSign.Model.UserSignaturesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_signatures_get_user_signatures(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_signatures_get_user_signatures(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UserSignaturesInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -251,7 +251,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_post_user_signatures(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -296,7 +296,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:ok, DocuSign.Model.UserSignaturesInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_signatures_put_user_signature(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_signatures_put_user_signature(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UserSignaturesInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -341,7 +341,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_put_user_signature_by_id(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -393,7 +393,7 @@ defmodule DocuSign.Api.UserSignatures do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_signatures_put_user_signature_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/users.ex
+++ b/lib/docusign/api/users.ex
@@ -34,7 +34,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.UserInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_get_user(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_get_user(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UserInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -76,7 +76,7 @@ defmodule DocuSign.Api.Users do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_profile_image_delete_user_profile_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -114,7 +114,7 @@ defmodule DocuSign.Api.Users do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_profile_image_get_user_profile_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -156,7 +156,7 @@ defmodule DocuSign.Api.Users do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec user_profile_image_put_user_profile_image(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           keyword()
@@ -195,7 +195,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.UserInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_put_user(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_put_user(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, UserInformation.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -237,7 +237,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.UserSettingsInformation.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_settings_get_user_settings(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_settings_get_user_settings(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, UserSettingsInformation.t()}
           | {:error, Tesla.Env.t()}
@@ -274,7 +274,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec user_settings_put_user_settings(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec user_settings_put_user_settings(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, nil} | {:ok, ErrorDetails.t()} | {:error, Tesla.Env.t()}
   def user_settings_put_user_settings(connection, account_id, user_id, opts \\ []) do
     optional_params = %{
@@ -315,7 +315,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.UsersResponse.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec users_delete_users(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec users_delete_users(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, UsersResponse.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -368,7 +368,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.UserInformationList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec users_get_users(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec users_get_users(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, UserInformationList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -420,7 +420,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.NewUsersSummary.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec users_post_users(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec users_post_users(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, ErrorDetails.t()}
           | {:ok, NewUsersSummary.t()}
           | {:error, Tesla.Env.t()}
@@ -462,7 +462,7 @@ defmodule DocuSign.Api.Users do
   - `{:ok, DocuSign.Model.UserInformationList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec users_put_users(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec users_put_users(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, UserInformationList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/api/workspace_items.ex
+++ b/lib/docusign/api/workspace_items.ex
@@ -35,7 +35,7 @@ defmodule DocuSign.Api.WorkspaceItems do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec workspace_file_get_workspace_file(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -87,7 +87,7 @@ defmodule DocuSign.Api.WorkspaceItems do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec workspace_file_pages_get_workspace_file_pages(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -146,7 +146,7 @@ defmodule DocuSign.Api.WorkspaceItems do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec workspace_file_post_workspace_files(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -190,7 +190,7 @@ defmodule DocuSign.Api.WorkspaceItems do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec workspace_file_put_workspace_file(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -235,7 +235,7 @@ defmodule DocuSign.Api.WorkspaceItems do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec workspace_folder_delete_workspace_items(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),
@@ -286,7 +286,7 @@ defmodule DocuSign.Api.WorkspaceItems do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec workspace_folder_get_workspace_folder(
-          Tesla.Env.client(),
+          DocuSign.Connection.t(),
           String.t(),
           String.t(),
           String.t(),

--- a/lib/docusign/api/workspaces.ex
+++ b/lib/docusign/api/workspaces.ex
@@ -29,7 +29,7 @@ defmodule DocuSign.Api.Workspaces do
   - `{:ok, DocuSign.Model.Workspace.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec workspace_delete_workspace(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec workspace_delete_workspace(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, Workspace.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -64,7 +64,7 @@ defmodule DocuSign.Api.Workspaces do
   - `{:ok, DocuSign.Model.Workspace.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec workspace_get_workspace(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec workspace_get_workspace(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, Workspace.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -98,7 +98,7 @@ defmodule DocuSign.Api.Workspaces do
   - `{:ok, DocuSign.Model.WorkspaceList.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec workspace_get_workspaces(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec workspace_get_workspaces(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, WorkspaceList.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -133,7 +133,7 @@ defmodule DocuSign.Api.Workspaces do
   - `{:ok, DocuSign.Model.Workspace.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec workspace_post_workspace(Tesla.Env.client(), String.t(), keyword()) ::
+  @spec workspace_post_workspace(DocuSign.Connection.t(), String.t(), keyword()) ::
           {:ok, Workspace.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}
@@ -175,7 +175,7 @@ defmodule DocuSign.Api.Workspaces do
   - `{:ok, DocuSign.Model.Workspace.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec workspace_put_workspace(Tesla.Env.client(), String.t(), String.t(), keyword()) ::
+  @spec workspace_put_workspace(DocuSign.Connection.t(), String.t(), String.t(), keyword()) ::
           {:ok, Workspace.t()}
           | {:ok, ErrorDetails.t()}
           | {:error, Tesla.Env.t()}

--- a/lib/docusign/file_downloader.ex
+++ b/lib/docusign/file_downloader.ex
@@ -27,7 +27,7 @@ defmodule DocuSign.FileDownloader do
       {:ok, {content, filename, content_type}} = DocuSign.FileDownloader.download_to_memory(conn, url)
 
       # Download with options
-      {:ok, result} = DocuSign.FileDownloader.download(conn, url, 
+      {:ok, result} = DocuSign.FileDownloader.download(conn, url,
         strategy: :file,
         filename: "custom_name.pdf",
         temp_dir: "/custom/temp"
@@ -44,6 +44,8 @@ defmodule DocuSign.FileDownloader do
         track_temp_files: true
 
   """
+
+  alias Connection
 
   require Logger
 
@@ -94,7 +96,7 @@ defmodule DocuSign.FileDownloader do
   ## Examples
 
       # Download envelope document to temporary file
-      {:ok, temp_path} = DocuSign.FileDownloader.download(conn, 
+      {:ok, temp_path} = DocuSign.FileDownloader.download(conn,
         "/v2.1/accounts/123/envelopes/456/documents/1")
 
       # Download with custom temp options
@@ -126,7 +128,7 @@ defmodule DocuSign.FileDownloader do
   @doc """
   Downloads a file to a temporary location.
 
-  Returns `{:ok, filepath}` on success, where filepath is the path to the 
+  Returns `{:ok, filepath}` on success, where filepath is the path to the
   temporary file. The caller is responsible for cleaning up the temporary file.
 
   ## Examples
@@ -136,7 +138,8 @@ defmodule DocuSign.FileDownloader do
       File.rm!(temp_path)  # Clean up
 
   """
-  @spec download_to_temp(DocuSign.Connection.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  @spec download_to_temp(DocuSign.Connection.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
   def download_to_temp(conn, url, opts \\ []) do
     download(conn, url, Keyword.put(opts, :strategy, :temp))
   end
@@ -148,7 +151,7 @@ defmodule DocuSign.FileDownloader do
 
   ## Examples
 
-      {:ok, {pdf_content, "document.pdf", "application/pdf"}} = 
+      {:ok, {pdf_content, "document.pdf", "application/pdf"}} =
         DocuSign.FileDownloader.download_to_memory(conn, url)
 
   """
@@ -284,7 +287,9 @@ defmodule DocuSign.FileDownloader do
     request_opts = []
 
     request_opts =
-      if opts[:max_size], do: Keyword.put(request_opts, :max_body_length, opts[:max_size]), else: request_opts
+      if opts[:max_size],
+        do: Keyword.put(request_opts, :max_body_length, opts[:max_size]),
+        else: request_opts
 
     case DocuSign.Connection.request(conn, method: :get, url: url, opts: request_opts) do
       {:ok, %Tesla.Env{status: status} = response} when status in 200..299 ->


### PR DESCRIPTION
- Replace Tesla.Env.client() with DocuSign.Connection.t() in all API module specs
- Add Dialyzer check to CI workflow (runs on latest Elixir/OTP version)
- Update .dialyzer_ignore.exs to handle false positive warnings
- Add alias for Connection module in FileDownloader for cleaner code

This resolves the Dialyzer type checking errors reported in issue #76 where
the API functions were expecting Tesla.Env.client() but actually receive
DocuSign.Connection.t() instances.
