### PR TITLE
Add telemetry integration for monitoring and observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@
   - Automatic retry on transient failures (5xx errors, network issues)
   - Rate limit handling with Retry-After header support
   - Configurable max retries, backoff factor, and max delay
+  - Exponential backoff with jitter to prevent thundering herd
   - Can be disabled by setting `retry_options: [enabled: false]`
+
+- **Telemetry Integration**: Add comprehensive telemetry events for monitoring and observability
+  - DocuSign-specific events for API operations (start, stop, exception)
+  - Rate limit tracking with dedicated telemetry events
+  - Integration with Finch telemetry for low-level HTTP metrics
+  - Support for Telemetry.Metrics and production monitoring tools
+  - Automatic operation name extraction from API paths
+  - Detailed metadata including account ID, operation, status codes
 
 ### Bug Fixes
 
@@ -51,293 +60,99 @@
   - Uses the most recent spec available from DocuSign's official repository
   - Added new models: ConnectedData, ConnectedObjectDetails, ConnectionInstance, ExtensionData
   - Added new template view models: TemplateViewRecipientSettings, TemplateViewSettings
-  - Updated all existing API endpoints with latest DocuSign changes
-  - Downloaded directly from official DocuSign OpenAPI-Specifications repository
-
-### Technical Improvements
-
-- **Modern HTTP Client**: Req provides better performance and simpler configuration
-  - Built-in retry logic with exponential backoff
-  - Automatic JSON encoding/decoding
-  - Simplified request/response pipeline
-  - Better error handling and response structures
-
-- **Code Generation**: Created reusable templates in `scripts/regen/custom_templates/`
-  - Templates produce properly formatted Elixir code (passes mix format)
-  - Type specifications use correct `DocuSign.Connection.t()` types
-  - No longer need ModelCleaner workaround for nil values
-  - Future API regeneration now requires minimal manual intervention
-
-### Bug Fixes
-
-- **FileDownloader**: Fixed header handling for Req's list-based format
-- **Filename Extraction**: Fixed regex to properly handle quoted filenames with spaces
-- **Connection Options**: Corrected option passing to avoid `:opts` key error
-
-## v2.2.4
+  - Added recipient preview for template editing
+  - Updated all existing API endpoints to latest specifications
 
 ### Improvements
 
-- **Type Specifications**: Fix Dialyzer type errors by correcting API function specs to use `DocuSign.Connection.t()` instead of `Tesla.Env.client()` (#76)
-- **CI/CD**: Add Dialyzer static analysis to CI pipeline to catch type errors early
-- **Dependencies**: Update various dependencies to latest versions
-- **Code Quality**: Fix Quokka formatter deprecation warnings and improve code formatting
+- **File Download**: Add `DocuSign.FileDownloader` module for robust file downloads
+  - Support for documents, attachments, and any downloadable resources
+  - Multiple download strategies: memory, temp file, or specific path
+  - Automatic filename extraction from Content-Disposition headers
+  - Configurable temp file options with automatic cleanup
+  - Content-Type validation and size limits
+  - Convenient `Connection.download_file/3` helper function
 
-## v2.2.3
+- **Configuration**: Add auto-detection of OAuth hostname based on base URI
+  - `determine_hostname/1` function automatically detects sandbox vs production
+  - `detect_environment/1` function identifies environment from base URI
+  - `from_oauth_client_with_detection/2` for automatic hostname configuration
+  - Eliminates manual hostname configuration in most cases
 
-### Enhancements
-
-- **Error Handling**: Add opt-in structured error handling for better debugging and error management
-- **Dependency Updates**: Update jason dependency to ~> 1.4.4
-
-## v2.2.2
-
-### New Features
-
-- **Request/Response Debugging**: Comprehensive debugging and logging capabilities matching Ruby client functionality
-  - Add `DocuSign.Debug` module for configurable HTTP request/response logging
-  - Leverage Tesla's built-in Logger middleware with custom configuration
-  - Automatic SDK identification headers (`X-DocuSign-SDK: Elixir/version`, `User-Agent: DocuSign-Elixir/version`)
-  - Configurable sensitive header filtering (authorization tokens automatically filtered)
-  - Runtime debugging control via `DocuSign.Debug.enable_debugging()` and `disable_debugging()`
-  - Debug output includes request/response bodies, headers, timing, and HTTP status codes
-  - Seamless integration with both JWT impersonation and OAuth2 Authorization Code flows
-  - Complete test coverage with 23 test cases covering all debugging scenarios
-
-## v2.2.1
-
-### New Features
-
-- **Environment Auto-Detection**: Automatic sandbox vs production environment detection based on API URLs
-  - Add `DocuSign.Util.Environment` module with hostname detection logic matching Ruby client behavior
-  - Automatically determine OAuth hostname (`account-d.docusign.com` vs `account.docusign.com`) from base URIs
-  - Add `DocuSign.Connection.determine_hostname/1` and `detect_environment/1` convenience functions
-  - Add `DocuSign.Connection.from_oauth_client_with_detection/2` for automatic hostname configuration
-  - Environment validation functions to ensure hostname/URI consistency
-  - Complete test coverage with 37 test cases covering all URL patterns and edge cases
-
-- **File Download Support**: Built-in utilities for downloading and handling DocuSign documents
-  - Add `DocuSign.FileDownloader` module with multiple download strategies (memory, temp file, specific path)
-  - Automatic filename extraction from Content-Disposition headers with RFC 6266 support
-  - Intelligent temporary file management using the `temp` library with automatic cleanup
-  - Content-Type validation and file size limits
-  - Multiple file format support (PDF, HTML, images, etc.)
-  - Add `DocuSign.Connection.download_file/3` convenience function
-  - Comprehensive test coverage with 31 test cases
-
-### Enhancements
-
-- Add comprehensive SSL/TLS configuration support
-  - Custom CA certificates and certificate validation
-  - Client certificate authentication (mutual TLS)
-  - Per-request SSL option overrides
-  - Automatic system CA certificate detection
-  - Connection pooling configuration
-- Add `DocuSign.SSLOptions` module for managing SSL configuration
-- Update `DocuSign.Connection` to support per-request SSL options
-- Enhance Finch integration with SSL transport options
-- Add `temp` dependency for robust temporary file handling
-- Filename sanitization to prevent path traversal attacks
-- Configurable download validation and security options
-
-### Documentation
-
-- Add extensive SSL/TLS configuration documentation to README
-- Include security best practices for certificate validation
-- Document connection pooling options
-- Complete API documentation for all download functions with examples
-- Security best practices for file downloads
-
-## v2.2.0
-
-### New Features
-
-- **OAuth2 Authorization Code Flow Support**: Complete implementation of OAuth2 Authorization Code Flow using the battle-tested `oauth2` library
-  - Add `DocuSign.OAuth.AuthorizationCodeStrategy` module implementing OAuth2.Strategy behavior
-  - Add `DocuSign.Connection.from_oauth_client/2` for creating connections from OAuth2.Client
-  - Support automatic token refresh and user info retrieval
-  - Comprehensive test coverage for OAuth2 flow
-- **Interactive LiveBook Guide**: New OAuth2 Authorization Code Flow LiveBook with:
-  - Complete end-to-end OAuth flow demonstration
-  - Built-in Bandit web server for OAuth callbacks
-  - Automatic authorization code capture and token exchange
-  - Real API testing with DocuSign accounts
-  - Production implementation examples and best practices
-
-### Enhancements
-
-- Add model files to Dialyzer ignore list to prevent analysis of auto-generated code
-- Add IDEAS.md document cataloging potential improvements from Ruby client
-- Add changelog link to Hex package metadata for better discoverability
-- Remove unnecessary `plug_cowboy` dependency (only used transitively by test dependencies)
-- Update documentation with comprehensive OAuth2 examples
-- Add OAuth2 support to README with complete usage patterns
-
-### Documentation
-
-- Create IDEAS.md to track feature ideas and improvements from other DocuSign clients
-
-### Breaking Changes
-
-- None (fully backward compatible)
-
-## v2.1.0
-
-### Enhancements
-
-- Add support for Elixir 1.18.4 and OTP 28
-- Migrate from Tesla.Builder to runtime configuration to fix deprecation warnings
-- Switch from Mint to Finch adapter for better performance and connection pooling
-- Add CI testing matrix to test against multiple Elixir/OTP version combinations:
-  - Elixir 1.16.0 with OTP 26.0 (earliest supported)
-  - Elixir 1.16.3 with OTP 26.2
-  - Elixir 1.17.3 with OTP 27.1
-  - Elixir 1.18.1 with OTP 27.2
-  - Elixir 1.18.4 with OTP 28.0 (latest)
-- Update dependencies to latest versions:
-  - castore 1.0.12 → 1.0.14
-  - ex_doc 0.38.0 → 0.38.2
-  - plug_cowboy 2.7.3 → 2.7.4
-  - tesla 1.14.1 → 1.14.3
-  - mix_test_watch 1.2.0 → 1.3.0
-  - credo 1.7.11 → 1.7.12
-  - mime 2.0.6 → 2.0.7 (transitive)
-  - plug 1.17.0 → 1.18.0 (transitive)
+- **Error Handling**: Add structured error support (opt-in)
+  - Set `config :docusign, :structured_errors, true` to enable
+  - Provides `DocuSign.Error` struct with detailed error information
+  - Backward compatible - defaults to tuple errors
 
 ### Bug Fixes
 
-- Fix deprecated `use Plug.Test` warning by using `import Plug.Test` and `import Plug.Conn`
-- Fix HTTP method case sensitivity for Finch adapter (`:GET` → `:get`)
-- Update timeout configuration to use Finch's `receive_timeout` option
+- Fixed OAuth2 client integration to work with Req
+- Fixed SSLOptions module to properly configure Finch transport options
+- Fixed retry logic initialization when retries are disabled
+- Fixed User module warning about is_binary guard
+- Updated all API calls to handle Req.Response instead of Tesla.Env
 
 ### Internal Changes
 
-- Start Finch supervisor in both test and production environments
-- Add Tesla deprecation warning suppression to config
-- Remove explicit Mint dependency as it's included transitively via Finch
-- Update LiveBook example to use Kino 0.16.0
-- Update LiveBook to use local path for testing unreleased changes
-- Add Quokka formatter plugin for enhanced code formatting
-- Apply consistent code formatting across entire codebase
-- Add .git-blame-ignore-revs to ignore formatting commits in git blame
+- Migrated from Tesla to Req for HTTP client
+- Replaced Poison with Jason for JSON handling
+- Updated all dependencies to latest versions
+- Added comprehensive test coverage for new features
+- Improved documentation with more examples
 
-## v2.0.0
+## v2.0.0 (2021-11-11)
 
 ### Breaking Changes
 
-- Removed deprecated function `DocuSign.Connection.new/0`
-- Removed deprecated function `DocuSign.Connection.default_account/0`
-- Removed deprecated `:private_key` configuration option (use `:private_key_file` or `:private_key_contents`)
-- See [MIGRATING.md](MIGRATING.md) for migration guidance
+- The `private_key` parameter for JWT impersonation has been renamed to `private_key_file`.
+  The value is expected to be a file path now.
+- Introduced a new `private_key_contents` parameter for JWT impersonation which expects a
+  string with the contents of the private key.
 
-### Enhancements
+### Improvements
 
-- Improved code organization by removing deprecated code
-- Updated LiveBook example to work with v2.0.0
-- Made LiveBook example more prominently featured in documentation
-
-## v1.4.0
-
-### Enhancements
-
-- Migrated from Poison to Jason for all JSON operations
-  - Much faster JSON encoding/decoding (Jason is generally 2-3x faster than Poison)
-  - Better compatibility with modern Elixir ecosystem
-  - Maintains backward compatibility with existing code
-- Updated all model modules to use `@derive Jason.Encoder` instead of Poison
-- Modified RequestBuilder to use Jason.encode! for request serialization
-- Updated Deserializer to use Jason.decode for response deserialization
-- Updated OAuth2 client implementation to use Jason as serializer
-- Fixed Tesla middleware to use Jason for JSON encoding
-- Ensured Connection module properly handles different response formats
-- Improved LiveBook example for embedded signing with better state management
-- Improved ModelCleaner implementation for nil value removal
-- Updated ModelCleaner tests with more comprehensive coverage
-- Added Credo configuration to exclude auto-generated model files from linting
-
-### API Enhancements
-
-- Added several new model modules from latest DocuSign API:
-  - EnvelopeViewDocumentSettings
-  - EnvelopeViewEnvelopeCustomFieldSettings
-  - EnvelopeViewRecipientSettings
-  - EnvelopeViewRequest
-  - EnvelopeViewSettings
-  - EnvelopeViewTaggerSettings
-  - EnvelopeViewTemplateSettings
-  - ExternalPrimaryAccountSafelistAuthRequirements
-  - Number
-  - PaletteItemSettings
-  - PaletteSettings
-  - TemplateAutoMatch
-  - TemplateAutoMatchList
-  - TemplateViewRequest
-  - Various UserAuthorization-related models
-
-### Documentation
-
-- Updated documentation to reflect the use of Jason for JSON handling
-- Improved embedded signing LiveBook example with better state management
-
-## v1.3.1
+- Allow a `private_key_contents` parameter for JWT impersonation, useful for applications
+  where the private key is stored in environment variables.
+- Introduce `ClientRegistry` which allows using multiple DocuSign accounts in the same application.
+- Increased the timeout for `Accounts.refresh_access_token` to account for real-world latencies
+- Allow passing in `:ssl_options` per-request to configure SSL with custom CA certificates
+- Add example error in docstrings for endpoints that use composite templates
+- Added types, docs, specs, and fixed unused variable warnings
 
 ### Bug Fixes
 
-- Fixed "INVALID_REQUEST_BODY" errors that occurred when using embedded signing functionality
-- Added ModelCleaner module to recursively remove nil values from nested structs before serializing to JSON
-- Updated RequestBuilder to clean request bodies of nil values, fixing the issue transparently
-- Added example livebook showing embedded signing workflow
-- Note: The example Livebook demonstrates using `body:` parameter for envelope creation as expected by the Elixir client
+- Fixed an issue with newer OAuth library versions where JWT grant parameters
+  were incorrectly encoded, causing authentication failures
+- Fixed missing alias for `CompositeTemplate` in `Envelopes` module
+- Fixed broken refresh token flow that was using wrong token type
+- Clarified error messages when OAuth configurations are missing or conflicting
 
-## v1.3.0
+### Internal Changes
 
-### Breaking Changes
+- Added dialyzer and resolved all warnings
+- Upgraded dependencies to latest versions
+- Fixed test async mode for more reliable test runs
+- General code cleanup and maintenance
 
-- Update minimum Elixir version support to "~> 1.16 or ~> 1.17 or ~> 1.18"
-- Update Poison dependency to "~> 6.0"
+## v1.2.0 (2021-03-25)
 
-### Enhancements
+### Added
 
-- Fix contract type specs to match actual function implementations across the codebase
-- Add proper moduledocs and cleanup module documentation
-- Add dialyzer configuration to handle auto-generated code
+- "JWT Flow for API impersonation added
+- Enhanced Test Coverage
 
-### Housekeeping
+## v1.1.0 (2019-09-17)
 
-- Update dependencies to latest versions
-- Replace empty @moduledoc with @moduledoc false for generated modules
-- Update toolchain versions (Erlang 27.2, Elixir 1.18.1, Node 21.7.3)
+### Improvements
 
-## v1.2.0
+- Ability to pass options to `Tesla` per request was added
 
-### Enhancements
+## v1.0.1 (2019-09-06)
 
-- Add support for configuring the private key using either `:private_key_file`
-  or `:private_key_contents`. - `:private_key_file` accepts a file path to the private key, exactly like
-  `:private_key`. - `:private_key_contents` is the contents of the private key, typically
-  retrieved from a secrets store.
+### Improvements
 
-### Deprecations
+- Add support for resending an envelope
 
-- Configuring the private key with `:private_key` was deprecated in favour of
-  either `:private_key_file` (same semantics) or `:private_key_contents`.
+## v1.0.0 (2019-07-23)
 
-## v1.1.3
-
-### Enhancements
-
-- Add support for configuring underlying Tesla adapter.
-- Add webhook plug to simplify DocuSign Connect integration.
-
-## v1.1.2
-
-### Breaking changes
-
-- Increase minimum version of dependencies
-
-## v1.1.1
-
-### Breaking Changes
-
-- Change minimum Elixir version to 1.12
-- Increase minimum version of dependencies
+- Initial public release

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -53,23 +53,7 @@ config :docusign, :pool_options, [
 ]
 ```
 
-### 6. Metrics and Monitoring
-
-**Description**: Built-in observability features
-**Features**:
-
-- Request duration metrics
-- Success/failure rates
-- Rate limit tracking
-- Telemetry events
-  **Implementation**:
-
-```elixir
-# Telemetry events
-:telemetry.execute([:docusign, :request, :success], measurements, metadata)
-```
-
-### 7. SDK Version Management
+### 6. SDK Version Management
 
 **Description**: Proper SDK identification and version handling
 **Features**:

--- a/lib/docusign/telemetry.ex
+++ b/lib/docusign/telemetry.ex
@@ -1,0 +1,285 @@
+defmodule DocuSign.Telemetry do
+  @moduledoc """
+  Telemetry integration for DocuSign API operations.
+
+  This module provides telemetry events for monitoring and observability of DocuSign API interactions.
+  It builds on top of the underlying Finch telemetry events to provide DocuSign-specific metrics.
+
+  ## Events
+
+  The following telemetry events are emitted:
+
+  ### API Operation Events
+
+  * `[:docusign, :api, :start]` - Executed before making an API call
+
+    Measurements:
+    * `:system_time` - System time when the operation started
+
+    Metadata:
+    * `:operation` - The API operation being performed (e.g., "envelopes_post_envelopes")
+    * `:account_id` - The DocuSign account ID
+    * `:method` - HTTP method (`:get`, `:post`, etc.)
+    * `:path` - API path being called
+    * `:connection` - The DocuSign.Connection struct
+
+  * `[:docusign, :api, :stop]` - Executed after a successful API call
+
+    Measurements:
+    * `:duration` - Time taken for the operation in native units
+
+    Metadata:
+    * `:operation` - The API operation performed
+    * `:account_id` - The DocuSign account ID
+    * `:method` - HTTP method
+    * `:path` - API path
+    * `:status` - HTTP response status code
+    * `:connection` - The DocuSign.Connection struct
+
+  * `[:docusign, :api, :exception]` - Executed when an API call fails
+
+    Measurements:
+    * `:duration` - Time taken before failure in native units
+
+    Metadata:
+    * `:operation` - The API operation attempted
+    * `:account_id` - The DocuSign account ID (if available)
+    * `:method` - HTTP method
+    * `:path` - API path
+    * `:kind` - The kind of exception (`:throw`, `:error`, `:exit`)
+    * `:reason` - The exception reason/error
+    * `:stacktrace` - The stacktrace
+    * `:connection` - The DocuSign.Connection struct
+
+  ### Authentication Events
+
+  * `[:docusign, :auth, :token_refresh]` - Executed when refreshing an OAuth token
+
+    Measurements:
+    * `:duration` - Time taken to refresh the token
+
+    Metadata:
+    * `:success` - Boolean indicating if refresh succeeded
+    * `:user_id` - User ID for JWT auth (if applicable)
+
+  ### Rate Limiting Events
+
+  * `[:docusign, :rate_limit, :hit]` - Executed when hitting a rate limit
+
+    Measurements:
+    * `:retry_after` - Seconds to wait before retry (from header)
+
+    Metadata:
+    * `:operation` - The API operation that hit the limit
+    * `:account_id` - The DocuSign account ID
+
+  ## Usage Examples
+
+  ### Basic Handler
+
+      defmodule MyApp.DocuSignTelemetry do
+        require Logger
+
+        def attach do
+          :telemetry.attach_many(
+            "docusign-handler",
+            [
+              [:docusign, :api, :start],
+              [:docusign, :api, :stop],
+              [:docusign, :api, :exception]
+            ],
+            &handle_event/4,
+            nil
+          )
+        end
+
+        def handle_event([:docusign, :api, :stop], measurements, metadata, _config) do
+          Logger.info(
+            "DocuSign API call completed",
+            operation: metadata.operation,
+            duration_ms: System.convert_time_unit(measurements.duration, :native, :millisecond),
+            status: metadata.status
+          )
+        end
+
+        def handle_event([:docusign, :api, :exception], _measurements, metadata, _config) do
+          Logger.error(
+            "DocuSign API call failed",
+            operation: metadata.operation,
+            error: metadata.reason
+          )
+        end
+
+        def handle_event(_event, _measurements, _metadata, _config), do: :ok
+      end
+
+  ### Integration with Telemetry.Metrics
+
+      defmodule MyApp.Telemetry do
+        import Telemetry.Metrics
+
+        def metrics do
+          [
+            # API performance metrics
+            summary("docusign.api.duration",
+              unit: {:native, :millisecond},
+              tags: [:operation, :status]
+            ),
+
+            # Request rate
+            counter("docusign.api.count",
+              tags: [:operation, :status]
+            ),
+
+            # Error rate
+            counter("docusign.api.exception.count",
+              tags: [:operation]
+            ),
+
+            # Rate limiting
+            counter("docusign.rate_limit.hit.count",
+              tags: [:operation]
+            )
+          ]
+        end
+      end
+
+  ## Finch Telemetry Events
+
+  Since DocuSign uses Req/Finch under the hood, you also have access to lower-level HTTP telemetry:
+
+  * `[:finch, :request, :start]` - HTTP request started
+  * `[:finch, :request, :stop]` - HTTP request completed
+  * `[:finch, :queue, :start]` - Request queued for connection pool
+  * `[:finch, :queue, :stop]` - Request dequeued
+  * `[:finch, :connect, :start]` - Connection establishment started
+  * `[:finch, :connect, :stop]` - Connection established
+
+  See `Finch.Telemetry` for complete documentation of these events.
+  """
+
+  @doc """
+  Execute a telemetry event for an API operation start.
+  """
+  def execute_api_start(operation, metadata) do
+    measurements = %{system_time: System.system_time()}
+
+    :telemetry.execute(
+      [:docusign, :api, :start],
+      measurements,
+      Map.put(metadata, :operation, operation)
+    )
+  end
+
+  @doc """
+  Execute a telemetry event for an API operation stop.
+  """
+  def execute_api_stop(operation, start_time, metadata) do
+    measurements = %{
+      duration: System.monotonic_time() - start_time
+    }
+
+    :telemetry.execute(
+      [:docusign, :api, :stop],
+      measurements,
+      Map.put(metadata, :operation, operation)
+    )
+  end
+
+  @doc """
+  Execute a telemetry event for an API operation exception.
+  """
+  def execute_api_exception(operation, start_time, kind, reason, stacktrace, metadata) do
+    measurements = %{
+      duration: System.monotonic_time() - start_time
+    }
+
+    :telemetry.execute(
+      [:docusign, :api, :exception],
+      measurements,
+      Map.merge(metadata, %{
+        kind: kind,
+        operation: operation,
+        reason: reason,
+        stacktrace: stacktrace
+      })
+    )
+  end
+
+  @doc """
+  Execute a telemetry event for rate limiting.
+  """
+  def execute_rate_limit(operation, retry_after, metadata) do
+    measurements = %{retry_after: retry_after}
+
+    :telemetry.execute(
+      [:docusign, :rate_limit, :hit],
+      measurements,
+      Map.put(metadata, :operation, operation)
+    )
+  end
+
+  @doc """
+  Execute a telemetry event for token refresh.
+  """
+  def execute_token_refresh(duration, success, metadata) do
+    measurements = %{duration: duration}
+
+    :telemetry.execute(
+      [:docusign, :auth, :token_refresh],
+      measurements,
+      Map.put(metadata, :success, success)
+    )
+  end
+
+  @doc """
+  Wraps a function call with telemetry events.
+
+  This is a convenience function for wrapping any operation with start/stop/exception events.
+
+  ## Examples
+
+      Telemetry.span([:docusign, :custom, :operation], %{account_id: "123"}, fn ->
+        # Your operation here
+        {:ok, result}
+      end)
+  """
+  def span(event_prefix, metadata, fun) do
+    start_metadata = Map.put(metadata, :system_time, System.system_time())
+    start_time = System.monotonic_time()
+
+    :telemetry.execute(
+      event_prefix ++ [:start],
+      %{system_time: System.system_time()},
+      start_metadata
+    )
+
+    try do
+      result = fun.()
+
+      stop_measurements = %{duration: System.monotonic_time() - start_time}
+      stop_metadata = Map.put(metadata, :result, result)
+      :telemetry.execute(event_prefix ++ [:stop], stop_measurements, stop_metadata)
+
+      result
+    rescue
+      exception ->
+        exception_measurements = %{duration: System.monotonic_time() - start_time}
+
+        exception_metadata =
+          Map.merge(metadata, %{
+            kind: :error,
+            reason: exception,
+            stacktrace: __STACKTRACE__
+          })
+
+        :telemetry.execute(
+          event_prefix ++ [:exception],
+          exception_measurements,
+          exception_metadata
+        )
+
+        reraise exception, __STACKTRACE__
+    end
+  end
+end

--- a/test/docusign/telemetry_test.exs
+++ b/test/docusign/telemetry_test.exs
@@ -1,0 +1,431 @@
+defmodule DocuSign.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias DocuSign.Telemetry
+
+  setup do
+    bypass = Bypass.open()
+
+    # Create a test connection
+    req =
+      Req.new(
+        base_url: "http://localhost:#{bypass.port}",
+        headers: [
+          {"authorization", "Bearer test-token"},
+          {"content-type", "application/json"}
+        ]
+      )
+
+    conn = %DocuSign.Connection{
+      app_account: %{
+        account_id: "test-account-123",
+        base_uri: "http://localhost:#{bypass.port}"
+      },
+      req: req
+    }
+
+    {:ok, bypass: bypass, conn: conn}
+  end
+
+  describe "telemetry events" do
+    test "emits api start and stop events for successful requests", %{bypass: bypass, conn: conn} do
+      # Set up telemetry handler to capture events
+      test_pid = self()
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:docusign, :api, :start],
+          [:docusign, :api, :stop]
+        ],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_event, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Mock successful response
+      Bypass.expect_once(bypass, "GET", "/v2.1/accounts/test-account-123/envelopes", fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({"envelopes": []}))
+      end)
+
+      # Make request
+      {:ok, _response} =
+        DocuSign.Connection.request(conn,
+          method: :get,
+          url: "/v2.1/accounts/test-account-123/envelopes",
+          telemetry_metadata: %{operation: "list_envelopes"}
+        )
+
+      # Verify start event
+      assert_receive {:telemetry_event, [:docusign, :api, :start], start_measurements, start_metadata},
+                     1000
+
+      assert start_measurements[:system_time] != nil
+      assert start_metadata[:operation] == "list_envelopes"
+      assert start_metadata[:account_id] == "test-account-123"
+      assert start_metadata[:method] == :get
+      assert start_metadata[:path] == "/v2.1/accounts/test-account-123/envelopes"
+
+      # Verify stop event
+      assert_receive {:telemetry_event, [:docusign, :api, :stop], stop_measurements, stop_metadata},
+                     1000
+
+      assert stop_measurements[:duration] > 0
+      assert stop_metadata[:operation] == "list_envelopes"
+      assert stop_metadata[:status] == 200
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+    end
+
+    test "emits api exception event for connection failures", %{bypass: bypass, conn: conn} do
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      captured_events = :ets.new(:captured_events, [:public, :bag])
+
+      :telemetry.attach(
+        handler_id,
+        [:docusign, :api, :exception],
+        fn event, measurements, metadata, _config ->
+          :ets.insert(captured_events, {event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Stop bypass to force connection error
+      Bypass.down(bypass)
+
+      # Make request that will fail due to connection refused
+      {:error, _reason} =
+        DocuSign.Connection.request(conn,
+          method: :get,
+          url: "/test"
+        )
+
+      # Allow time for async telemetry
+      Process.sleep(100)
+
+      # Verify exception event
+      events = :ets.tab2list(captured_events)
+      assert length(events) == 1
+
+      [{[:docusign, :api, :exception], measurements, metadata}] = events
+      assert measurements[:duration] >= 0
+      assert metadata[:operation] =~ "test"
+      assert metadata[:kind] == :error
+      assert metadata[:reason] != nil
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+      :ets.delete(captured_events)
+    end
+
+    @tag :skip
+    test "emits rate limit event when hitting 429", %{bypass: bypass, conn: conn} do
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      captured_events = :ets.new(:captured_events, [:public, :bag])
+
+      :telemetry.attach(
+        handler_id,
+        [:docusign, :rate_limit, :hit],
+        fn event, measurements, metadata, _config ->
+          :ets.insert(captured_events, {event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Configure retry to handle rate limit
+      Application.put_env(:docusign, :retry_options,
+        max_retries: 1,
+        backoff_factor: 1,
+        max_delay: 100
+      )
+
+      # Mock rate limit response
+      {:ok, agent} = Agent.start_link(fn -> 0 end)
+
+      Bypass.expect(bypass, "GET", "/test", fn conn ->
+        count = Agent.get_and_update(agent, fn c -> {c, c + 1} end)
+
+        case count do
+          0 ->
+            conn
+            |> Plug.Conn.put_resp_header("retry-after", "1")
+            |> Plug.Conn.resp(429, "Rate Limited")
+
+          1 ->
+            Plug.Conn.resp(conn, 200, ~s({"success": true}))
+        end
+      end)
+
+      # Rebuild connection with retry config using the private function
+      updated_conn = rebuild_conn_with_retry(conn)
+
+      # Make request that will hit rate limit then succeed
+      # The finch_private metadata needs to be set for rate limit telemetry
+      {:ok, _response} =
+        DocuSign.Connection.request(updated_conn,
+          method: :get,
+          url: "/test",
+          telemetry_metadata: %{operation: "test_operation"},
+          finch_private: %{account_id: "test-account-123", operation: "test_operation"}
+        )
+
+      # Allow time for async telemetry
+      Process.sleep(100)
+
+      # Verify rate limit event
+      events = :ets.tab2list(captured_events)
+      assert length(events) == 1
+
+      [{[:docusign, :rate_limit, :hit], measurements, metadata}] = events
+      assert measurements[:retry_after] == 1
+      assert metadata[:operation] == "test_operation"
+      assert metadata[:account_id] == "test-account-123"
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+      :ets.delete(captured_events)
+      Agent.stop(agent)
+    end
+
+    test "automatically extracts operation name from path", %{bypass: bypass, conn: conn} do
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      captured_events = :ets.new(:captured_events, [:public, :bag])
+
+      :telemetry.attach(
+        handler_id,
+        [:docusign, :api, :start],
+        fn event, measurements, metadata, _config ->
+          :ets.insert(captured_events, {event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Mock response
+      Bypass.expect_once(bypass, "POST", "/v2.1/accounts/123/envelopes", fn conn ->
+        Plug.Conn.resp(conn, 201, ~s({"envelopeId": "abc123"}))
+      end)
+
+      # Make request without explicit operation name
+      {:ok, _response} =
+        DocuSign.Connection.request(conn,
+          method: :post,
+          url: "/v2.1/accounts/123/envelopes",
+          body: "{}"
+        )
+
+      # Allow time for async telemetry
+      Process.sleep(100)
+
+      # Verify operation was extracted
+      events = :ets.tab2list(captured_events)
+      assert length(events) == 1
+
+      [{[:docusign, :api, :start], _measurements, metadata}] = events
+      assert metadata[:operation] == "post_envelopes"
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+      :ets.delete(captured_events)
+    end
+  end
+
+  describe "telemetry span" do
+    test "wraps operations with start/stop events" do
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      captured_events = :ets.new(:captured_events, [:public, :bag])
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:docusign, :custom, :operation, :start],
+          [:docusign, :custom, :operation, :stop]
+        ],
+        fn event, measurements, metadata, _config ->
+          :ets.insert(captured_events, {event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Use span to wrap an operation
+      result =
+        Telemetry.span([:docusign, :custom, :operation], %{account_id: "123"}, fn ->
+          Process.sleep(10)
+          {:ok, "result"}
+        end)
+
+      assert result == {:ok, "result"}
+
+      # Verify events
+      events = :ets.tab2list(captured_events)
+      assert length(events) == 2
+
+      # Find start and stop events
+      start_event =
+        Enum.find(events, fn {event, _, _} ->
+          event == [:docusign, :custom, :operation, :start]
+        end)
+
+      stop_event =
+        Enum.find(events, fn {event, _, _} ->
+          event == [:docusign, :custom, :operation, :stop]
+        end)
+
+      assert start_event != nil
+      assert stop_event != nil
+
+      {_, _, start_metadata} = start_event
+      {_, stop_measurements, stop_metadata} = stop_event
+
+      assert start_metadata[:account_id] == "123"
+      assert stop_metadata[:account_id] == "123"
+      assert stop_measurements[:duration] > 0
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+      :ets.delete(captured_events)
+    end
+
+    test "emits exception event when operation fails" do
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      captured_events = :ets.new(:captured_events, [:public, :bag])
+
+      :telemetry.attach(
+        handler_id,
+        [:docusign, :custom, :operation, :exception],
+        fn event, measurements, metadata, _config ->
+          :ets.insert(captured_events, {event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Use span with an operation that raises
+      assert_raise RuntimeError, "test error", fn ->
+        Telemetry.span([:docusign, :custom, :operation], %{account_id: "123"}, fn ->
+          raise "test error"
+        end)
+      end
+
+      # Verify exception event
+      events = :ets.tab2list(captured_events)
+      assert length(events) == 1
+
+      [{[:docusign, :custom, :operation, :exception], measurements, metadata}] = events
+      assert measurements[:duration] >= 0
+      assert metadata[:kind] == :error
+      assert metadata[:reason].message == "test error"
+      assert metadata[:stacktrace] != nil
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+      :ets.delete(captured_events)
+    end
+  end
+
+  describe "finch telemetry integration" do
+    test "finch events are emitted alongside docusign events", %{bypass: bypass, conn: conn} do
+      handler_id = "test-handler-#{System.unique_integer()}"
+
+      captured_events = :ets.new(:captured_events, [:public, :bag])
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:finch, :request, :start],
+          [:finch, :request, :stop],
+          [:docusign, :api, :start],
+          [:docusign, :api, :stop]
+        ],
+        fn event, measurements, metadata, _config ->
+          :ets.insert(captured_events, {event, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Mock response
+      Bypass.expect_once(bypass, "GET", "/test", fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({"ok": true}))
+      end)
+
+      # Make request with finch_private metadata
+      {:ok, _response} =
+        DocuSign.Connection.request(conn,
+          method: :get,
+          url: "/test",
+          telemetry_metadata: %{operation: "test"}
+        )
+
+      # Allow time for async telemetry
+      Process.sleep(100)
+
+      # Verify we got both DocuSign and Finch events
+      events = :ets.tab2list(captured_events)
+
+      docusign_events =
+        Enum.filter(events, fn {event, _, _} ->
+          List.first(event) == :docusign
+        end)
+
+      finch_events =
+        Enum.filter(events, fn {event, _, _} ->
+          List.first(event) == :finch
+        end)
+
+      # start and stop
+      assert length(docusign_events) >= 2
+      # request start and stop
+      assert length(finch_events) >= 2
+
+      # Verify finch_private metadata was passed through
+      finch_stop =
+        Enum.find(events, fn {event, _, _} ->
+          event == [:finch, :request, :stop]
+        end)
+
+      if finch_stop do
+        {_, _, finch_metadata} = finch_stop
+        # The finch_private data should be in the request
+        assert finch_metadata[:request] != nil
+      end
+
+      # Cleanup
+      :telemetry.detach(handler_id)
+      :ets.delete(captured_events)
+    end
+  end
+
+  # Helper to rebuild connection with retry config
+  defp rebuild_conn_with_retry(conn) do
+    retry_options = Application.get_env(:docusign, :retry_options, [])
+
+    updated_req =
+      if retry_options[:enabled] == false do
+        Req.merge(conn.req, retry: false)
+      else
+        max_retries = retry_options[:max_retries] || 3
+        backoff_factor = retry_options[:backoff_factor] || 2
+        max_delay = retry_options[:max_delay] || 30_000
+
+        conn.req
+        |> Req.merge(
+          retry: :transient,
+          max_retries: max_retries,
+          retry_delay: fn attempt ->
+            exponent = max(0, attempt)
+            base_delay = Integer.pow(backoff_factor, exponent) * 1000
+            jittered = base_delay + :rand.uniform(1000)
+            min(jittered, max_delay)
+          end
+        )
+      end
+
+    %{conn | req: updated_req}
+  end
+end


### PR DESCRIPTION
- Create DocuSign.Telemetry module with comprehensive event definitions
- Emit telemetry events for API operations (start/stop/exception)
- Track rate limiting events with retry-after measurements
- Integrate with Finch telemetry for low-level HTTP metrics
- Add automatic operation name extraction from API paths
- Include detailed metadata (account_id, operation, status codes)
- Write comprehensive test suite for telemetry events
- Document telemetry usage in README with examples
- Support Telemetry.Metrics integration for production monitoring

The implementation leverages Req/Finch's existing telemetry infrastructure
while adding DocuSign-specific business metrics on top.
