### PR TITLE
Add SDK version management with comprehensive User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   - Automatic operation name extraction from API paths
   - Detailed metadata including account ID, operation, status codes
 
+- **SDK Version Management**: Add proper SDK identification and version reporting
+  - User-Agent header includes SDK version, API version, and runtime info
+  - Format: `docusign-elixir/3.0.0 (Elixir/1.18.4; OTP/28; API/v2.1)`
+  - SDK metadata included in all telemetry events
+  - Support for custom User-Agent suffix for app identification
+  - Matches Ruby SDK pattern for version reporting
+
 ### Bug Fixes
 
 - **Test Stability**: Fix flaky async tests caused by Mock library

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -53,15 +53,6 @@ config :docusign, :pool_options, [
 ]
 ```
 
-### 6. SDK Version Management
-
-**Description**: Proper SDK identification and version handling
-**Features**:
-
-- User-Agent header management
-- SDK version reporting
-- API version compatibility checks
-
 ## Architecture Principles to Maintain
 
 ### Keep Superior Elixir Patterns
@@ -98,7 +89,7 @@ config :docusign, :pool_options, [
 - Unit tests for individual modules
 - Integration tests with DocuSign sandbox
 - Property-based testing where applicable
-- Mocking for external dependencies
+- Use Bypass for HTTP mocking
 
 ## Long-term Vision
 

--- a/lib/docusign/connection.ex
+++ b/lib/docusign/connection.ex
@@ -377,11 +377,13 @@ defmodule DocuSign.Connection do
       end
 
     metadata =
-      Map.merge(telemetry_meta, %{
+      telemetry_meta
+      |> Map.merge(%{
         account_id: account_id,
         method: method,
         path: path
       })
+      |> Map.merge(DocuSign.SDKVersion.metadata())
 
     start_time = System.monotonic_time()
     DocuSign.Telemetry.execute_api_start(operation, metadata)

--- a/lib/docusign/debug.ex
+++ b/lib/docusign/debug.ex
@@ -90,11 +90,12 @@ defmodule DocuSign.Debug do
   """
   @spec sdk_headers() :: [{String.t(), String.t()}]
   def sdk_headers do
-    version = Application.spec(:docusign, :vsn) |> to_string()
+    user_agent = DocuSign.SDKVersion.user_agent()
+    sdk_version = DocuSign.SDKVersion.version()
 
     [
-      {"X-DocuSign-SDK", "Elixir/#{version}"},
-      {"User-Agent", "DocuSign-Elixir/#{version}"}
+      {"X-DocuSign-SDK", "Elixir/#{sdk_version}"},
+      {"User-Agent", user_agent}
     ]
   end
 

--- a/lib/docusign/sdk_version.ex
+++ b/lib/docusign/sdk_version.ex
@@ -1,0 +1,94 @@
+defmodule DocuSign.SDKVersion do
+  @moduledoc """
+  SDK version information and User-Agent header management.
+
+  This module provides version information about the DocuSign Elixir SDK
+  and formats the User-Agent header for API requests.
+  """
+
+  @sdk_version "3.0.0"
+  @api_version "v2.1"
+  @sdk_name "docusign-elixir"
+
+  @doc """
+  Returns the SDK version.
+
+  ## Examples
+
+      iex> DocuSign.SDKVersion.version()
+      "3.0.0"
+
+  """
+  @spec version() :: String.t()
+  def version, do: @sdk_version
+
+  @doc """
+  Returns the API version this SDK targets.
+
+  ## Examples
+
+      iex> DocuSign.SDKVersion.api_version()
+      "v2.1"
+
+  """
+  @spec api_version() :: String.t()
+  def api_version, do: @api_version
+
+  @doc """
+  Generates the User-Agent string for HTTP requests.
+
+  Includes SDK version, API version, and runtime information (Elixir and OTP versions).
+
+  ## Options
+
+    * `:custom_suffix` - Optional custom string to append to the User-Agent
+
+  ## Examples
+
+      iex> DocuSign.SDKVersion.user_agent()
+      "docusign-elixir/3.0.0 (Elixir/1.16.0; OTP/26.0; API/v2.1)"
+
+      iex> DocuSign.SDKVersion.user_agent(custom_suffix: "MyApp/1.0")
+      "docusign-elixir/3.0.0 (Elixir/1.16.0; OTP/26.0; API/v2.1) MyApp/1.0"
+
+  """
+  @spec user_agent(keyword()) :: String.t()
+  def user_agent(opts \\ []) do
+    elixir_version = System.version()
+    otp_version = :erlang.system_info(:otp_release) |> List.to_string()
+
+    base_agent =
+      "#{@sdk_name}/#{@sdk_version} (Elixir/#{elixir_version}; OTP/#{otp_version}; API/#{@api_version})"
+
+    case Keyword.get(opts, :custom_suffix) do
+      nil -> base_agent
+      suffix -> "#{base_agent} #{suffix}"
+    end
+  end
+
+  @doc """
+  Returns a map of SDK metadata for telemetry and logging.
+
+  ## Examples
+
+      iex> DocuSign.SDKVersion.metadata()
+      %{
+        sdk_name: "docusign-elixir",
+        sdk_version: "3.0.0",
+        api_version: "v2.1",
+        elixir_version: "1.16.0",
+        otp_version: "26"
+      }
+
+  """
+  @spec metadata() :: map()
+  def metadata do
+    %{
+      api_version: @api_version,
+      elixir_version: System.version(),
+      otp_version: :erlang.system_info(:otp_release) |> List.to_string(),
+      sdk_name: @sdk_name,
+      sdk_version: @sdk_version
+    }
+  end
+end

--- a/test/docusign/connection_debug_test.exs
+++ b/test/docusign/connection_debug_test.exs
@@ -99,7 +99,7 @@ defmodule DocuSign.ConnectionDebugTest do
       # Find User-Agent header (value might be a list)
       {_, ua_value} = Enum.find(headers, fn {k, _} -> String.downcase(k) == "user-agent" end)
       ua_string = if is_list(ua_value), do: List.first(ua_value), else: ua_value
-      assert ua_string =~ "DocuSign-Elixir/"
+      assert ua_string =~ "docusign-elixir/"
     end
   end
 end

--- a/test/docusign/debug_test.exs
+++ b/test/docusign/debug_test.exs
@@ -63,7 +63,7 @@ defmodule DocuSign.DebugTest do
 
       # Check for User-Agent header
       assert {"User-Agent", user_agent} = List.keyfind(headers, "User-Agent", 0)
-      assert user_agent =~ ~r/^DocuSign-Elixir\/\d+\.\d+\.\d+/
+      assert user_agent =~ ~r/^docusign-elixir\/\d+\.\d+\.\d+/
     end
   end
 

--- a/test/docusign/sdk_version_test.exs
+++ b/test/docusign/sdk_version_test.exs
@@ -1,0 +1,79 @@
+defmodule DocuSign.SDKVersionTest do
+  use ExUnit.Case, async: true
+
+  alias DocuSign.SDKVersion
+
+  describe "version/0" do
+    test "returns the SDK version" do
+      assert SDKVersion.version() == "3.0.0"
+    end
+  end
+
+  describe "api_version/0" do
+    test "returns the API version" do
+      assert SDKVersion.api_version() == "v2.1"
+    end
+  end
+
+  describe "user_agent/1" do
+    test "generates proper user agent string" do
+      user_agent = SDKVersion.user_agent()
+
+      # Check basic structure
+      assert user_agent =~
+               ~r/^docusign-elixir\/3\.0\.0 \(Elixir\/[\d\.]+; OTP\/[\d]+; API\/v2\.1\)$/
+
+      # Check it contains Elixir version
+      assert user_agent =~ "Elixir/#{System.version()}"
+
+      # Check it contains OTP version
+      otp_version = :erlang.system_info(:otp_release) |> List.to_string()
+      assert user_agent =~ "OTP/#{otp_version}"
+
+      # Check it contains API version
+      assert user_agent =~ "API/v2.1"
+    end
+
+    test "supports custom suffix" do
+      user_agent = SDKVersion.user_agent(custom_suffix: "MyApp/1.0.0")
+
+      assert user_agent =~
+               ~r/^docusign-elixir\/3\.0\.0 \(Elixir\/[\d\.]+; OTP\/[\d]+; API\/v2\.1\) MyApp\/1\.0\.0$/
+
+      assert user_agent =~ " MyApp/1.0.0"
+    end
+
+    test "handles nil custom suffix" do
+      user_agent = SDKVersion.user_agent(custom_suffix: nil)
+
+      refute user_agent =~ " nil"
+
+      assert user_agent =~
+               ~r/^docusign-elixir\/3\.0\.0 \(Elixir\/[\d\.]+; OTP\/[\d]+; API\/v2\.1\)$/
+    end
+  end
+
+  describe "metadata/0" do
+    test "returns complete metadata map" do
+      metadata = SDKVersion.metadata()
+
+      assert metadata.sdk_name == "docusign-elixir"
+      assert metadata.sdk_version == "3.0.0"
+      assert metadata.api_version == "v2.1"
+      assert metadata.elixir_version == System.version()
+
+      otp_version = :erlang.system_info(:otp_release) |> List.to_string()
+      assert metadata.otp_version == otp_version
+    end
+
+    test "metadata has all expected keys" do
+      metadata = SDKVersion.metadata()
+
+      expected_keys = [:sdk_name, :sdk_version, :api_version, :elixir_version, :otp_version]
+
+      for key <- expected_keys do
+        assert Map.has_key?(metadata, key), "Missing key: #{key}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add DocuSign.SDKVersion module for version info and User-Agent
- Include SDK version, API version, Elixir/OTP versions in User-Agent
- Format: docusign-elixir/3.0.0 (Elixir/1.18.4; OTP/28; API/v2.1)
- Add SDK metadata to telemetry events for better observability
- Support custom suffix for User-Agent (for app identification)
- Update Debug.sdk_headers() to use new SDKVersion module
- Matches Ruby SDK pattern of including version in all API calls
