### PR TITLE
Add Elixir 1.19-rc.0 to test matrix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,6 +22,9 @@ jobs:
           # Latest 1.18 series with OTP 28
           - elixir: "1.18.4"
             otp: "28.0"
+          # Testing with 1.19 RC
+          - elixir: "1.19.0-rc.0"
+            otp: "28.0"
     steps:
       - uses: actions/checkout@v3
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 28.0.2
-elixir 1.18.4-otp-28
+erlang 28.0
+elixir 1.19.0-rc.0-otp-28
 nodejs 24.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### CI/Testing
+
+- Add Elixir 1.19-rc.0 to test matrix for early compatibility testing
+- Fix test regex patterns to support RC version formats
+
 ## v3.1.1 (2025-09-04)
 
 ### Documentation

--- a/test/docusign/sdk_version_test.exs
+++ b/test/docusign/sdk_version_test.exs
@@ -23,7 +23,7 @@ defmodule DocuSign.SDKVersionTest do
 
       # Check basic structure using the actual version
       expected_pattern =
-        ~r/^docusign-elixir\/#{Regex.escape(version)} \(Elixir\/[\d\.]+; OTP\/[\d]+; API\/v2\.1\)$/
+        ~r/^docusign-elixir\/#{Regex.escape(version)} \(Elixir\/[\d\.\-\w]+; OTP\/[\d]+; API\/v2\.1\)$/
 
       assert user_agent =~ expected_pattern
 
@@ -43,7 +43,7 @@ defmodule DocuSign.SDKVersionTest do
       version = SDKVersion.version()
 
       expected_pattern =
-        ~r/^docusign-elixir\/#{Regex.escape(version)} \(Elixir\/[\d\.]+; OTP\/[\d]+; API\/v2\.1\) MyApp\/1\.0\.0$/
+        ~r/^docusign-elixir\/#{Regex.escape(version)} \(Elixir\/[\d\.\-\w]+; OTP\/[\d]+; API\/v2\.1\) MyApp\/1\.0\.0$/
 
       assert user_agent =~ expected_pattern
 
@@ -57,7 +57,7 @@ defmodule DocuSign.SDKVersionTest do
       refute user_agent =~ " nil"
 
       expected_pattern =
-        ~r/^docusign-elixir\/#{Regex.escape(version)} \(Elixir\/[\d\.]+; OTP\/[\d]+; API\/v2\.1\)$/
+        ~r/^docusign-elixir\/#{Regex.escape(version)} \(Elixir\/[\d\.\-\w]+; OTP\/[\d]+; API\/v2\.1\)$/
 
       assert user_agent =~ expected_pattern
     end


### PR DESCRIPTION
Adds Elixir 1.19-rc.0 to CI test matrix and fixes regex patterns in tests to support RC version formats.