### PR TITLE
elixir 1.19 support

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,9 +22,9 @@ jobs:
           # Latest 1.18 series with OTP 28
           - elixir: "1.18.4"
             otp: "28.0"
-          # Testing with 1.19 RC
-          - elixir: "1.19.0-rc.0"
-            otp: "28.0"
+          # Latest 1.19 series with OTP 28
+          - elixir: "1.19.0"
+            otp: "28.1"
     steps:
       - uses: actions/checkout@v3
 
@@ -75,9 +75,9 @@ jobs:
           mix test --trace
 
       - name: Check formatting
-        if: matrix.elixir == '1.18.4' && matrix.otp == '28.0'
+        if: matrix.elixir == '1.19.0' && matrix.otp == '28.1'
         run: mix format --check-formatted
 
       - name: Run Dialyzer
-        if: matrix.elixir == '1.18.4' && matrix.otp == '28.0'
+        if: matrix.elixir == '1.19.0' && matrix.otp == '28.1'
         run: mix dialyzer

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 28.0
-elixir 1.19.0-rc.0-otp-28
+erlang 28.1
+elixir 1.19.0-otp-28
 nodejs 24.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### CI/Testing
 
-- Add Elixir 1.19-rc.0 to test matrix for early compatibility testing
-- Fix test regex patterns to support RC version formats
+- Add Elixir 1.19.0 and OTP 28.1 to test matrix
+- Update .tool-versions to Elixir 1.19.0 and OTP 28.1
+- Update CI formatting and dialyzer checks to run on Elixir 1.19.0
 
 ## v3.1.1 (2025-09-04)
 


### PR DESCRIPTION
- **Add Elixir 1.19-rc.0 to test matrix and fix test regex patterns**
- **Update CHANGELOG for Elixir 1.19-rc.0 support**
- **Upgrade to Elixir 1.19.0 and OTP 28.1**
